### PR TITLE
Few improvements

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,733 @@
+## Table of contents
+
+- [\Swaggest\GoCodeBuilder\Import](#class-swaggestgocodebuilderimport)
+- [\Swaggest\GoCodeBuilder\GoCodeBuilder](#class-swaggestgocodebuildergocodebuilder)
+- [\Swaggest\GoCodeBuilder\Exception](#class-swaggestgocodebuilderexception)
+- [\Swaggest\GoCodeBuilder\JsonSchema\MarshalUnion](#class-swaggestgocodebuilderjsonschemamarshalunion)
+- [\Swaggest\GoCodeBuilder\JsonSchema\MarshalEnum](#class-swaggestgocodebuilderjsonschemamarshalenum)
+- [\Swaggest\GoCodeBuilder\JsonSchema\MarshalJson](#class-swaggestgocodebuilderjsonschemamarshaljson)
+- [\Swaggest\GoCodeBuilder\JsonSchema\GeneratedStruct](#class-swaggestgocodebuilderjsonschemageneratedstruct)
+- [\Swaggest\GoCodeBuilder\JsonSchema\StructHookCallback](#class-swaggestgocodebuilderjsonschemastructhookcallback)
+- [\Swaggest\GoCodeBuilder\JsonSchema\StripPrefixPathToNameHook](#class-swaggestgocodebuilderjsonschemastripprefixpathtonamehook)
+- [\Swaggest\GoCodeBuilder\JsonSchema\TypeBuilder](#class-swaggestgocodebuilderjsonschematypebuilder)
+- [\Swaggest\GoCodeBuilder\JsonSchema\Options](#class-swaggestgocodebuilderjsonschemaoptions)
+- [\Swaggest\GoCodeBuilder\JsonSchema\UnmarshalUnion](#class-swaggestgocodebuilderjsonschemaunmarshalunion)
+- [\Swaggest\GoCodeBuilder\JsonSchema\GoBuilderPathToNameHook (interface)](#interface-swaggestgocodebuilderjsonschemagobuilderpathtonamehook)
+- [\Swaggest\GoCodeBuilder\JsonSchema\GoBuilder](#class-swaggestgocodebuilderjsonschemagobuilder)
+- [\Swaggest\GoCodeBuilder\JsonSchema\GoBuilderStructHook (interface)](#interface-swaggestgocodebuilderjsonschemagobuilderstructhook)
+- [\Swaggest\GoCodeBuilder\JsonSchema\Exception](#class-swaggestgocodebuilderjsonschemaexception)
+- [\Swaggest\GoCodeBuilder\Style\Initialisms](#class-swaggestgocodebuilderstyleinitialisms)
+- [\Swaggest\GoCodeBuilder\Templates\Code](#class-swaggestgocodebuildertemplatescode)
+- [\Swaggest\GoCodeBuilder\Templates\Imports](#class-swaggestgocodebuildertemplatesimports)
+- [\Swaggest\GoCodeBuilder\Templates\GoTemplate (abstract)](#class-swaggestgocodebuildertemplatesgotemplate-abstract)
+- [\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)
+- [\Swaggest\GoCodeBuilder\Templates\Constant\TypeConstBlock](#class-swaggestgocodebuildertemplatesconstanttypeconstblock)
+- [\Swaggest\GoCodeBuilder\Templates\Func\Argument](#class-swaggestgocodebuildertemplatesfuncargument)
+- [\Swaggest\GoCodeBuilder\Templates\Func\FuncIface](#class-swaggestgocodebuildertemplatesfuncfunciface)
+- [\Swaggest\GoCodeBuilder\Templates\Func\Result](#class-swaggestgocodebuildertemplatesfuncresult)
+- [\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)
+- [\Swaggest\GoCodeBuilder\Templates\Func\Arguments](#class-swaggestgocodebuildertemplatesfuncarguments)
+- [\Swaggest\GoCodeBuilder\Templates\Iface\IfaceDef](#class-swaggestgocodebuildertemplatesifaceifacedef)
+- [\Swaggest\GoCodeBuilder\Templates\Mapping\Mapping](#class-swaggestgocodebuildertemplatesmappingmapping)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructFunctions](#class-swaggestgocodebuildertemplatesstructstructfunctions)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructFields](#class-swaggestgocodebuildertemplatesstructstructfields)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructType](#class-swaggestgocodebuildertemplatesstructstructtype)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\Tags](#class-swaggestgocodebuildertemplatesstructtags)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructProperty](#class-swaggestgocodebuildertemplatesstructstructproperty)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructCast](#class-swaggestgocodebuildertemplatesstructstructcast)
+- [\Swaggest\GoCodeBuilder\Templates\Struct\StructIface](#class-swaggestgocodebuildertemplatesstructstructiface)
+- [\Swaggest\GoCodeBuilder\Templates\Type\TypeCast](#class-swaggestgocodebuildertemplatestypetypecast)
+- [\Swaggest\GoCodeBuilder\Templates\Type\TypeCastException](#class-swaggestgocodebuildertemplatestypetypecastexception)
+- [\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)
+- [\Swaggest\GoCodeBuilder\Templates\Type\FuncType](#class-swaggestgocodebuildertemplatestypefunctype)
+- [\Swaggest\GoCodeBuilder\Templates\Type\Map](#class-swaggestgocodebuildertemplatestypemap)
+- [\Swaggest\GoCodeBuilder\Templates\Type\Pointer](#class-swaggestgocodebuildertemplatestypepointer)
+- [\Swaggest\GoCodeBuilder\Templates\Type\Slice](#class-swaggestgocodebuildertemplatestypeslice)
+- [\Swaggest\GoCodeBuilder\Templates\Type\AnyType (interface)](#interface-swaggestgocodebuildertemplatestypeanytype)
+- [\Swaggest\GoCodeBuilder\Templates\Type\NamedType (interface)](#interface-swaggestgocodebuildertemplatestypenamedtype)
+- [\Swaggest\GoCodeBuilder\Templates\Type\TypeUtil](#class-swaggestgocodebuildertemplatestypetypeutil)
+- [\Swaggest\GoCodeBuilder\TypeCast\PropertyCast](#class-swaggestgocodebuildertypecastpropertycast)
+- [\Swaggest\GoCodeBuilder\TypeCast\Time](#class-swaggestgocodebuildertypecasttime)
+- [\Swaggest\GoCodeBuilder\TypeCast\Registry (interface)](#interface-swaggestgocodebuildertypecastregistry)
+- [\Swaggest\GoCodeBuilder\TypeCast\CastFunctions (interface)](#interface-swaggestgocodebuildertypecastcastfunctions)
+- [\Swaggest\GoCodeBuilder\TypeCast\CastRegistry](#class-swaggestgocodebuildertypecastcastregistry)
+- [\Swaggest\GoCodeBuilder\TypeCast\RegistryMux](#class-swaggestgocodebuildertypecastregistrymux)
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Import
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$name</strong>, <em>mixed</em> <strong>$alias=null</strong>, <em>mixed</em> <strong>$defaultPackageName=null</strong>)</strong> : <em>void</em> |
+| public | <strong>getPackage()</strong> : <em>string</em> |
+| public | <strong>getReferencePrefix()</strong> : <em>mixed</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\GoCodeBuilder
+
+> GoCodeBuilder provides file manager and names processor.
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct()</strong> : <em>void</em> |
+| public | <strong>exportableName(</strong><em>mixed</em> <strong>$name</strong>)</strong> : <em>void</em> |
+| public | <strong>privateName(</strong><em>mixed</em> <strong>$name</strong>)</strong> : <em>void</em> |
+| public | <strong>setBuilderVersion(</strong><em>mixed</em> <strong>$builderVersion</strong>)</strong> : <em>void</em> |
+| public | <strong>storeToDisk(</strong><em>mixed</em> <strong>$srcPath</strong>)</strong> : <em>void</em> |
+| protected | <strong>toCamelCase(</strong><em>string</em> <strong>$string</strong>, <em>bool</em> <strong>$lowerFirst=false</strong>)</strong> : <em>string</em> |
+
+*This class extends \Swaggest\CodeBuilder\CodeBuilder*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Exception
+
+| Visibility | Function |
+|:-----------|:---------|
+
+*This class extends \Exception*
+
+*This class implements \Throwable*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\MarshalUnion
+
+| Visibility | Function |
+|:-----------|:---------|
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\MarshalEnum
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> <strong>$type</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\NamedType](#interface-swaggestgocodebuildertemplatestypenamedtype)</em> <strong>$base</strong>, <em>array</em> <strong>$enum</strong>, <em>[\Swaggest\GoCodeBuilder\JsonSchema\GoBuilder](#class-swaggestgocodebuilderjsonschemagobuilder)</em> <strong>$builder</strong>)</strong> : <em>void</em><br /><em>MarshalEnum constructor.</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\MarshalJson
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\JsonSchema\GoBuilder](#class-swaggestgocodebuilderjsonschemagobuilder)</em> <strong>$builder</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$type</strong>)</strong> : <em>void</em> |
+| public | <strong>addNamedProperty(</strong><em>mixed</em> <strong>$name</strong>)</strong> : <em>void</em> |
+| public | <strong>addPatternProperty(</strong><em>mixed</em> <strong>$regex</strong>, <em>mixed</em> <strong>$name</strong>)</strong> : <em>void</em> |
+| public | <strong>addSomeOf(</strong><em>mixed</em> <strong>$kind</strong>, <em>mixed</em> <strong>$name</strong>)</strong> : <em>void</em> |
+| public | <strong>enableAdditionalProperties()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\GeneratedStruct
+
+| Visibility | Function |
+|:-----------|:---------|
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\StructHookCallback
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Closure](http://php.net/manual/en/class.closure.php)</em> <strong>$closure</strong>)</strong> : <em>void</em><br /><em>StructHookCallback constructor.</em> |
+| public | <strong>process(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$structDef</strong>, <em>mixed</em> <strong>$path</strong>, <em>mixed</em> <strong>$schema</strong>)</strong> : <em>void</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\JsonSchema\GoBuilderStructHook](#interface-swaggestgocodebuilderjsonschemagobuilderstructhook)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\StripPrefixPathToNameHook
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>pathToName(</strong><em>mixed</em> <strong>$path</strong>)</strong> : <em>void</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\JsonSchema\GoBuilderPathToNameHook](#interface-swaggestgocodebuilderjsonschemagobuilderpathtonamehook)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\TypeBuilder
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>\Swaggest\JsonSchema\Schema</em> <strong>$schema</strong>, <em>string</em> <strong>$path</strong>, <em>[\Swaggest\GoCodeBuilder\JsonSchema\GoBuilder](#class-swaggestgocodebuilderjsonschemagobuilder)</em> <strong>$goBuilder</strong>)</strong> : <em>void</em><br /><em>TypeBuilder constructor.</em> |
+| public | <strong>build()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>setParentName(</strong><em>mixed</em> <strong>$parentName</strong>)</strong> : <em>void</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\Options
+
+| Visibility | Function |
+|:-----------|:---------|
+| public static | <strong>setUpProperties(</strong><em>\Swaggest\GoCodeBuilder\JsonSchema\static</em> <strong>$properties</strong>, <em>\Swaggest\JsonSchema\Schema</em> <strong>$ownerSchema</strong>)</strong> : <em>void</em> |
+
+*This class extends \Swaggest\JsonSchema\Structure\ClassStructure*
+
+*This class implements \Swaggest\JsonSchema\Structure\WithResolvedValue, \Swaggest\JsonSchema\Structure\ObjectItemContract, \Traversable, \Iterator, \JsonSerializable, \ArrayAccess, \Swaggest\JsonSchema\Structure\ClassStructureContract*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\UnmarshalUnion
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>patternVarName(</strong><em>mixed</em> <strong>$pattern</strong>)</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\JsonSchema\GoBuilderPathToNameHook
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>pathToName(</strong><em>mixed</em> <strong>$path</strong>)</strong> : <em>void</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\GoBuilder
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct()</strong> : <em>void</em> |
+| public | <strong>getClass(</strong><em>\Swaggest\GoCodeBuilder\JsonSchema\Schema</em> <strong>$schema</strong>, <em>string</em> <strong>$path</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> |
+| public | <strong>getCode()</strong> : <em>mixed</em> |
+| public | <strong>getGeneratedStruct(</strong><em>\Swaggest\GoCodeBuilder\JsonSchema\Schema</em> <strong>$schema</strong>, <em>string</em> <strong>$path</strong>)</strong> : <em>mixed/[\Swaggest\GoCodeBuilder\JsonSchema\GeneratedStruct](#class-swaggestgocodebuilderjsonschemageneratedstruct)</em> |
+| public | <strong>getGeneratedStructs()</strong> : <em>[\Swaggest\GoCodeBuilder\JsonSchema\GeneratedStruct](#class-swaggestgocodebuilderjsonschemageneratedstruct)[]</em> |
+| public | <strong>getType(</strong><em>\Swaggest\GoCodeBuilder\JsonSchema\Schema</em> <strong>$schema</strong>, <em>string</em> <strong>$path=`'#'`</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>pathToName(</strong><em>mixed</em> <strong>$path</strong>)</strong> : <em>void</em> |
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\JsonSchema\GoBuilderStructHook
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>process(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$structDef</strong>, <em>string</em> <strong>$path</strong>, <em>\Swaggest\GoCodeBuilder\JsonSchema\Schema</em> <strong>$schema</strong>)</strong> : <em>null</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\JsonSchema\Exception
+
+| Visibility | Function |
+|:-----------|:---------|
+
+*This class extends \Exception*
+
+*This class implements \Throwable*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Style\Initialisms
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct()</strong> : <em>void</em> |
+| public | <strong>process(</strong><em>mixed</em> <strong>$goName</strong>)</strong> : <em>void</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Code
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$body=null</strong>)</strong> : <em>void</em> |
+| public | <strong>addSnippet(</strong><em>mixed</em> <strong>$code</strong>, <em>bool</em> <strong>$prepend=false</strong>, <em>mixed</em> <strong>$uniqueKey=null</strong>)</strong> : <em>void</em> |
+| public | <strong>imports()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Imports](#class-swaggestgocodebuildertemplatesimports)</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Imports
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>add(</strong><em>[\Swaggest\GoCodeBuilder\Import](#class-swaggestgocodebuilderimport)</em> <strong>$import</strong>)</strong> : <em>\Swaggest\GoCodeBuilder\Templates\$this</em> |
+| public | <strong>addByName(</strong><em>mixed</em> <strong>$name</strong>, <em>mixed</em> <strong>$alias=null</strong>)</strong> : <em>void</em> |
+| public | <strong>demand()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\GoTemplate (abstract)
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>escapeValue(</strong><em>mixed</em> <strong>$value</strong>)</strong> : <em>void</em> |
+| public | <strong>getComment()</strong> : <em>string</em> |
+| public | <strong>ifThenElse(</strong><em>mixed</em> <strong>$condition</strong>, <em>mixed</em> <strong>$then</strong>, <em>string</em> <strong>$else=`''`</strong>)</strong> : <em>void</em> |
+| public | <strong>padLines(</strong><em>mixed</em> <strong>$with</strong>, <em>mixed</em> <strong>$text</strong>, <em>bool</em> <strong>$skipFirst=true</strong>, <em>bool</em> <strong>$forcePad=false</strong>)</strong> : <em>void</em> |
+| public | <strong>setComment(</strong><em>mixed</em> <strong>$comment</strong>)</strong> : <em>void</em> |
+| public | <strong>stripEmptyLines(</strong><em>mixed</em> <strong>$text</strong>)</strong> : <em>void</em> |
+| public | <strong>trim(</strong><em>mixed</em> <strong>$s</strong>)</strong> : <em>void</em> |
+| protected | <strong>renderComment()</strong> : <em>void</em> |
+
+*This class extends \Swaggest\CodeBuilder\AbstractTemplate*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\GoFile
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>string</em> <strong>$package</strong>, <em>string/null</em> <strong>$importPath=null</strong>)</strong> : <em>void</em><br /><em>GoFile constructor.</em> |
+| public | <strong>commitTransaction()</strong> : <em>void</em> |
+| public | <strong>dropTransaction(</strong><em>bool</em> <strong>$ignoreMissing=true</strong>)</strong> : <em>void</em> |
+| public | <strong>getCode()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Code](#class-swaggestgocodebuildertemplatescode)</em> |
+| public | <strong>getComment()</strong> : <em>mixed</em> |
+| public static | <strong>getCurrentGoFile()</strong> : <em>mixed</em> |
+| public | <strong>getImportPath()</strong> : <em>null</em> |
+| public | <strong>getImports()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Imports](#class-swaggestgocodebuildertemplatesimports)</em> |
+| public | <strong>getPackage()</strong> : <em>mixed</em> |
+| public | <strong>setCode(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Code](#class-swaggestgocodebuildertemplatescode)</em> <strong>$code</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)</em> |
+| public static | <strong>setCurrentGoFile(</strong><em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)</em> <strong>$currentGoFile=null</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)/null previous go file</em> |
+| public | <strong>setDependentCode(</strong><em>mixed</em> <strong>$uniqueKey</strong>, <em>mixed</em> <strong>$value</strong>)</strong> : <em>void</em> |
+| public | <strong>setImportPath(</strong><em>null</em> <strong>$importPath</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)</em> |
+| public | <strong>setPackage(</strong><em>mixed</em> <strong>$package</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)</em> |
+| public | <strong>setSkipImportComment(</strong><em>boolean</em> <strong>$skipImportComment</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\GoFile](#class-swaggestgocodebuildertemplatesgofile)</em> |
+| public | <strong>startTransaction()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Constant\TypeConstBlock
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> <strong>$type</strong>)</strong> : <em>void</em> |
+| public | <strong>addValue(</strong><em>mixed</em> <strong>$name</strong>, <em>mixed</em> <strong>$value</strong>, <em>mixed</em> <strong>$comment=null</strong>)</strong> : <em>void</em> |
+| public | <strong>getValues()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Func\Argument
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>string</em> <strong>$name</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>, <em>bool</em> <strong>$isVariadic=false</strong>)</strong> : <em>void</em><br /><em>Argument constructor.</em> |
+| public | <strong>getType()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Func\FuncIface
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> <strong>$funcDef</strong>)</strong> : <em>void</em><br /><em>FuncIface constructor.</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Func\Result
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>toTypesString()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\Func\Arguments](#class-swaggestgocodebuildertemplatesfuncarguments)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Func\FuncDef
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>string</em> <strong>$name</strong>, <em>string</em> <strong>$comment=`''`</strong>)</strong> : <em>void</em><br /><em>FuncDef constructor.</em> |
+| public | <strong>getArguments()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\Arguments](#class-swaggestgocodebuildertemplatesfuncarguments)</em> |
+| public | <strong>getName()</strong> : <em>string</em> |
+| public | <strong>getRenderMode()</strong> : <em>string</em> |
+| public | <strong>getResult()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\Result](#class-swaggestgocodebuildertemplatesfuncresult)/null</em> |
+| public | <strong>getSelf()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\Argument](#class-swaggestgocodebuildertemplatesfuncargument)/null</em> |
+| public | <strong>setArguments(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\Arguments](#class-swaggestgocodebuildertemplatesfuncarguments)</em> <strong>$arguments</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>setBody(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Code](#class-swaggestgocodebuildertemplatescode)</em> <strong>$body</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>setName(</strong><em>string</em> <strong>$name</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>setRenderMode(</strong><em>string</em> <strong>$renderMode</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>setResult(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\Result](#class-swaggestgocodebuildertemplatesfuncresult)</em> <strong>$result=null</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>setSelf(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\Argument](#class-swaggestgocodebuildertemplatesfuncargument)</em> <strong>$self</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Func\Arguments
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>add(</strong><em>mixed</em> <strong>$name</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>, <em>bool</em> <strong>$isVariadic=false</strong>)</strong> : <em>void</em> |
+| public | <strong>count()</strong> : <em>void</em> |
+| public | <strong>toTypesString()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Iface\IfaceDef
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$name</strong>, <em>mixed</em> <strong>$comment=null</strong>)</strong> : <em>void</em> |
+| public | <strong>addFunc(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> <strong>$func</strong>, <em>bool</em> <strong>$prepend=false</strong>)</strong> : <em>void</em> |
+| public | <strong>addType(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> <strong>$func</strong>, <em>bool</em> <strong>$prepend=false</strong>)</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Mapping\Mapping
+
+| Visibility | Function |
+|:-----------|:---------|
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructFunctions
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$struct</strong>)</strong> : <em>void</em><br /><em>StructFunctions constructor.</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends \Swaggest\CodeBuilder\AbstractTemplate*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructFields
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$struct</strong>)</strong> : <em>void</em><br /><em>StructType constructor.</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructType
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$structDef</strong>)</strong> : <em>void</em><br /><em>StructType constructor.</em> |
+| public | <strong>getName()</strong> : <em>mixed</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\NamedType](#interface-swaggestgocodebuildertemplatestypenamedtype), [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructDef
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>string</em> <strong>$name</strong>, <em>string</em> <strong>$comment=`''`</strong>)</strong> : <em>void</em><br /><em>StructDef constructor.</em> |
+| public | <strong>addFunc(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> <strong>$func</strong>, <em>bool</em> <strong>$prepend=false</strong>)</strong> : <em>void</em> |
+| public | <strong>addProperty(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructProperty](#class-swaggestgocodebuildertemplatesstructstructproperty)</em> <strong>$property</strong>, <em>bool</em> <strong>$prepend=false</strong>)</strong> : <em>void</em> |
+| public | <strong>getCode()</strong> : <em>mixed</em> |
+| public | <strong>getFuncs()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)[]</em> |
+| public | <strong>getImport()</strong> : <em>\Swaggest\GoCodeBuilder\Templates\Struct\Import/null</em> |
+| public | <strong>getName()</strong> : <em>mixed</em> |
+| public | <strong>getProperties()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructProperty](#class-swaggestgocodebuildertemplatesstructstructproperty)[]</em> |
+| public | <strong>getType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructType](#class-swaggestgocodebuildertemplatesstructstructtype)</em> |
+| public | <strong>renderFields()</strong> : <em>void</em> |
+| public | <strong>renderFuncs()</strong> : <em>void</em> |
+| public | <strong>setImport(</strong><em>[\Swaggest\GoCodeBuilder\Import](#class-swaggestgocodebuilderimport)</em> <strong>$import=null</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> |
+| public | <strong>setName(</strong><em>mixed</em> <strong>$name</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> |
+| public | <strong>setType(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> <strong>$type</strong>)</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\Tags
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>setTag(</strong><em>mixed</em> <strong>$key</strong>, <em>mixed</em> <strong>$value</strong>)</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructProperty
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$name</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Struct\Tags](#class-swaggestgocodebuildertemplatesstructtags)</em> <strong>$tags=null</strong>)</strong> : <em>void</em> |
+| public | <strong>getName()</strong> : <em>string/null</em> |
+| public | <strong>getTags()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\Tags](#class-swaggestgocodebuildertemplatesstructtags)</em> |
+| public | <strong>getType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructCast
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$baseStruct</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$derivedStruct</strong>, <em>array/string[]</em> <strong>$propNamesMap=array()</strong>, <em>[\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)</em> <strong>$registry=null</strong>)</strong> : <em>void</em><br /><em>StructCast constructor.</em> |
+| public | <strong>getBaseStruct()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> |
+| public | <strong>getBaseTypeString()</strong> : <em>string</em> |
+| public | <strong>getDerivedStruct()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> |
+| public | <strong>getDerivedTypeString()</strong> : <em>string</em> |
+| public | <strong>getLoadFrom()</strong> : <em>mixed</em> |
+| public | <strong>getMapTo()</strong> : <em>mixed</em> |
+| public | <strong>setPropMap(</strong><em>mixed</em> <strong>$baseName</strong>, <em>mixed</em> <strong>$derivedName</strong>)</strong> : <em>void</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\TypeCast\CastFunctions](#interface-swaggestgocodebuildertypecastcastfunctions)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Struct\StructIface
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$struct</strong>, <em>mixed</em> <strong>$name</strong>, <em>string</em> <strong>$comment=`''`</strong>)</strong> : <em>void</em> |
+| public | <strong>getIface()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\TypeCast
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$toType</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$fromType</strong>, <em>string</em> <strong>$toVarName</strong>, <em>string</em> <strong>$fromVarName</strong>, <em>[\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)</em> <strong>$registry=null</strong>)</strong> : <em>void</em><br /><em>TypeCast constructor.</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\TypeCastException
+
+| Visibility | Function |
+|:-----------|:---------|
+
+*This class extends \Exception*
+
+*This class implements \Throwable*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\Type
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>mixed</em> <strong>$type</strong>, <em>[\Swaggest\GoCodeBuilder\Import](#class-swaggestgocodebuilderimport)</em> <strong>$import=null</strong>)</strong> : <em>void</em> |
+| public | <strong>equals(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> <strong>$type</strong>)</strong> : <em>void</em> |
+| public | <strong>getImport()</strong> : <em>\Swaggest\GoCodeBuilder\Templates\Type\Import/null</em> |
+| public | <strong>getName()</strong> : <em>mixed</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\NamedType](#interface-swaggestgocodebuildertemplatestypenamedtype), [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\FuncType
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> <strong>$func</strong>)</strong> : <em>void</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\Map
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$keyType</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$valueType</strong>)</strong> : <em>void</em><br /><em>Map constructor.</em> |
+| public | <strong>getKeyType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| public | <strong>getValueType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>renderName()</strong> : <em>void</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\Pointer
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>void</em><br /><em>Pointer constructor.</em> |
+| public | <strong>getType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| public static | <strong>tryDereferenceOnce(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\Slice
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>void</em><br /><em>Slice constructor.</em> |
+| public | <strong>getType()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> |
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| protected | <strong>toString()</strong> : <em>void</em> |
+
+*This class extends [\Swaggest\GoCodeBuilder\Templates\GoTemplate](#class-swaggestgocodebuildertemplatesgotemplate-abstract)*
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\Templates\Type\AnyType
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>getTypeString()</strong> : <em>mixed</em> |
+| public | <strong>render()</strong> : <em>void</em> |
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\Templates\Type\NamedType
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>getName()</strong> : <em>string</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\Templates\Type\TypeUtil
+
+| Visibility | Function |
+|:-----------|:---------|
+| public static | <strong>equals(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$one</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$two</strong>)</strong> : <em>void</em> |
+| public static | <strong>fromString(</strong><em>string</em> <strong>$typeString</strong>)</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)/[\Swaggest\GoCodeBuilder\Templates\Type\Type](#class-swaggestgocodebuildertemplatestypetype)</em> |
+| public static | <strong>getBasicType(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>mixed</em> |
+| public static | <strong>isCastable(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$to</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$from</strong>)</strong> : <em>bool</em> |
+| public static | <strong>isFloat(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>bool</em> |
+| public static | <strong>isInt(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>bool</em> |
+| public static | <strong>isNumber(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>bool</em> |
+| public static | <strong>resolvePointer(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$type</strong>)</strong> : <em>void</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\TypeCast\PropertyCast
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>__construct(</strong><em>[\Swaggest\GoCodeBuilder\Templates\Struct\StructDef](#class-swaggestgocodebuildertemplatesstructstructdef)</em> <strong>$baseStruct</strong>, <em>string</em> <strong>$propertyName</strong>, <em>[\Swaggest\GoCodeBuilder\Templates\Type\AnyType](#interface-swaggestgocodebuildertemplatestypeanytype)</em> <strong>$derivedType</strong>, <em>[\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)</em> <strong>$typeRegistry</strong>)</strong> : <em>void</em><br /><em>PropertyCast constructor.</em> |
+| public | <strong>getBaseTypeString()</strong> : <em>string</em> |
+| public | <strong>getDerivedTypeString()</strong> : <em>string</em> |
+| public | <strong>getLoadFrom()</strong> : <em>mixed</em> |
+| public | <strong>getMapTo()</strong> : <em>mixed</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\TypeCast\CastFunctions](#interface-swaggestgocodebuildertypecastcastfunctions)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\TypeCast\Time
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>canProcess(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>)</strong> : <em>bool</em> |
+| public | <strong>process(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>, <em>string</em> <strong>$toVarName</strong>, <em>string</em> <strong>$fromVarName</strong>, <em>string</em> <strong>$assignOp</strong>)</strong> : <em>\Swaggest\GoCodeBuilder\TypeCast\Code/string</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)*
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\TypeCast\Registry
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>canProcess(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>)</strong> : <em>bool</em> |
+| public | <strong>process(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>, <em>string</em> <strong>$toVarName</strong>, <em>string</em> <strong>$fromVarName</strong>, <em>string</em> <strong>$assignOp</strong>)</strong> : <em>\Swaggest\GoCodeBuilder\TypeCast\Code/string</em> |
+
+<hr />
+
+### Interface: \Swaggest\GoCodeBuilder\TypeCast\CastFunctions
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>getBaseTypeString()</strong> : <em>string</em> |
+| public | <strong>getDerivedTypeString()</strong> : <em>string</em> |
+| public | <strong>getLoadFrom()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+| public | <strong>getMapTo()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)</em> |
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\TypeCast\CastRegistry
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>addStructCast(</strong><em>[\Swaggest\GoCodeBuilder\TypeCast\CastFunctions](#interface-swaggestgocodebuildertypecastcastfunctions)</em> <strong>$cast</strong>)</strong> : <em>void</em> |
+| public | <strong>canProcess(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>)</strong> : <em>bool</em> |
+| public | <strong>process(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>, <em>string</em> <strong>$toVarName</strong>, <em>string</em> <strong>$fromVarName</strong>, <em>string</em> <strong>$assignOp</strong>)</strong> : <em>string</em> |
+| public | <strong>resetUsedCastFuncs()</strong> : <em>[\Swaggest\GoCodeBuilder\Templates\Func\FuncDef](#class-swaggestgocodebuildertemplatesfuncfuncdef)[]</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)*
+
+<hr />
+
+### Class: \Swaggest\GoCodeBuilder\TypeCast\RegistryMux
+
+| Visibility | Function |
+|:-----------|:---------|
+| public | <strong>addRegistry(</strong><em>[\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)</em> <strong>$registry</strong>)</strong> : <em>void</em> |
+| public | <strong>canProcess(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>)</strong> : <em>bool</em> |
+| public static | <strong>getStd()</strong> : <em>\Swaggest\GoCodeBuilder\TypeCast\static</em> |
+| public | <strong>process(</strong><em>string</em> <strong>$toTypeString</strong>, <em>string</em> <strong>$fromTypeString</strong>, <em>string</em> <strong>$toVarName</strong>, <em>string</em> <strong>$fromVarName</strong>, <em>string</em> <strong>$assignOp</strong>)</strong> : <em>\Swaggest\GoCodeBuilder\TypeCast\Code/string</em> |
+
+*This class implements [\Swaggest\GoCodeBuilder\TypeCast\Registry](#interface-swaggestgocodebuildertypecastregistry)*
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.7] - 2019-10-05
+
+### Added
+- Support for `x-go-type` as object (`go-swagger` format).
+- Builder option `$ignoreXGoType` to disregard `x-go-type` hints.
+- Builder option `$withZeroValues` to use pointer types to avoid zero-value ambiguity.
+- Builder option `$ignoreNullable` to enable `omitempty` for nullable properties.
+- Automated API docs.
+- Change log.
+
+### Fixed
+- Missing processing for `null` `additionalProperties`.
+- Processing for nullable (`[null, <other>]`) types.
+
+### Changed
+- Multi-type schemas are decomposed into multiple structures.
+- Schema title is used for structure name if available.
+
+## [0.4.6] - 2019-10-01
+
+### Added
+- More tests.
+- CI upgrade.
+
+### Fixed
+- Code-style issues.
+
+## [0.4.5] - 2019-07-11
+
+### Added
+- Type inference from enum values.
+
+### Changed
+- Trivial nesting removed. 
+
+## [0.4.4] - 2019-07-08
+
+### Fixed
+- Removed unnecessary regexp dependency, #7.
+
+[0.4.7]: https://github.com/swaggest/go-code-builder/compare/v0.4.6...v0.4.7
+[0.4.6]: https://github.com/swaggest/go-code-builder/compare/v0.4.5...v0.4.6
+[0.4.5]: https://github.com/swaggest/go-code-builder/compare/v0.4.4...v0.4.5
+[0.4.4]: https://github.com/swaggest/go-code-builder/compare/v0.4.3...v0.4.4

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ test-coverage:
 test-go:
 	@cd tests/resources/go
 	@go test ./...
+
+docs:
+	@php ./vendor/bin/phpdoc-md generate src > API.md
+

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ foreach ($builder->getGeneratedStructs() as $generatedStruct) {
 $goFile->getCode()->addSnippet($builder->getCode());
 ```
 
-## CLI tool
+## API Documentation
+
+Classes [documentation](API.md).
+
+## CLI Tool
 
 You can use [json-cli](https://github.com/swaggest/json-cli#gengo) to generate Go structures from command line.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "swaggest/json-schema": "^0.12.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5"
+    "phpunit/phpunit": "^5",
+    "victorjonsson/markdowndocs": "^1.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1ab23b3980c43fce95ea3d7a9239867",
+    "content-hash": "ba0a98cc0cb7eb67c6a46267e9468461",
     "packages": [
         {
             "name": "php-yaoi/php-yaoi",
@@ -1489,6 +1489,134 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v3.4.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "4510f04e70344d70952566e4262a0b11df39cb10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4510f04e70344d70952566e4262a0b11df39cb10",
+                "reference": "4510f04e70344d70952566e4262a0b11df39cb10",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/debug": "~2.8|~3.0|~4.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-08-26T07:52:58+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.4.31",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "0b600300918780001e2821db77bc28b677794486"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0b600300918780001e2821db77bc28b677794486",
+                "reference": "0b600300918780001e2821db77bc28b677794486",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-08-20T13:31:17+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.12.0",
             "source": {
@@ -1543,6 +1671,65 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "reference": "b42a2f66e8f1b15ccf25652c3424265923eb4f17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
             ],
             "time": "2019-08-06T08:03:45+00:00"
         },
@@ -1604,6 +1791,50 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2019-08-20T13:31:17+00:00"
+        },
+        {
+            "name": "victorjonsson/markdowndocs",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator.git",
+                "reference": "c5eb16ff5bd15ee60223883ddacba0ab8797268d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/victorjonsson/PHP-Markdown-Documentation-Generator/zipball/c5eb16ff5bd15ee60223883ddacba0ab8797268d",
+                "reference": "c5eb16ff5bd15ee60223883ddacba0ab8797268d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "symfony/console": ">=2.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.23"
+            },
+            "bin": [
+                "bin/phpdoc-md"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPDocsMD": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Victor Jonsson",
+                    "email": "kontakt@victorjonsson.se"
+                }
+            ],
+            "description": "Command line tool for generating markdown-formatted class documentation",
+            "homepage": "https://github.com/victorjonsson/PHP-Markdown-Documentation-Generator",
+            "time": "2017-04-20T09:52:47+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/GoCodeBuilder.php
+++ b/src/GoCodeBuilder.php
@@ -5,6 +5,9 @@ namespace Swaggest\GoCodeBuilder;
 use Swaggest\CodeBuilder\CodeBuilder;
 use Swaggest\GoCodeBuilder\Style\Initialisms;
 
+/**
+ * GoCodeBuilder provides file manager and names processor.
+ */
 class GoCodeBuilder extends CodeBuilder
 {
     public function __construct()

--- a/src/JsonSchema/MarshalUnion.php
+++ b/src/JsonSchema/MarshalUnion.php
@@ -8,8 +8,6 @@ use Swaggest\GoCodeBuilder\Templates\GoTemplate;
 
 class MarshalUnion extends GoTemplate
 {
-    public $withRegex;
-
     protected function toString()
     {
         $code = new Code();

--- a/src/JsonSchema/Options.php
+++ b/src/JsonSchema/Options.php
@@ -43,6 +43,24 @@ class Options extends ClassStructure
     public $skipMarshal = false;
 
     /**
+     * Generate structure for schema with `x-go-type` available.
+     * @var bool
+     */
+    public $ignoreXGoType = false;
+
+    /**
+     * Use pointer types to avoid zero value ambiguity.
+     * @var bool
+     */
+    public $withZeroValues = false;
+
+    /**
+     * Add omitempty to nullable values.
+     * @var bool
+     */
+    public $ignoreNullable = false;
+
+    /**
      * @param static $properties
      * @param Schema $ownerSchema
      */

--- a/src/Templates/Type/NoOmitEmpty.php
+++ b/src/Templates/Type/NoOmitEmpty.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Swaggest\GoCodeBuilder\Templates\Type;
+
+
+interface NoOmitEmpty
+{
+    /**
+     * @return bool
+     */
+    public function isNoOmitEmpty();
+
+}

--- a/src/Templates/Type/Pointer.php
+++ b/src/Templates/Type/Pointer.php
@@ -4,10 +4,32 @@ namespace Swaggest\GoCodeBuilder\Templates\Type;
 
 use Swaggest\GoCodeBuilder\Templates\GoTemplate;
 
-class Pointer extends GoTemplate implements AnyType
+class Pointer extends GoTemplate implements AnyType, NoOmitEmpty
 {
     /** @var AnyType */
     private $type;
+
+    /**
+     * Json tag `omitempty` should be avoided if this flag is true.
+     * @var bool
+     */
+    private $noOmitEmpty = false;
+
+    /**
+     * @return bool
+     */
+    public function isNoOmitEmpty()
+    {
+        return $this->noOmitEmpty;
+    }
+
+    /**
+     * @param bool $noOmitEmpty
+     */
+    public function setNoOmitEmpty($noOmitEmpty)
+    {
+        $this->noOmitEmpty = $noOmitEmpty;
+    }
 
     /**
      * Pointer constructor.

--- a/tests/resources/amqp-message-binding-object-0.1.0.json
+++ b/tests/resources/amqp-message-binding-object-0.1.0.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "AMQP 0-9-1 Operation Binding Object",
-  "description": "This object contains information about the operation representation in AMQP.\nSee https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.",
+  "title": "AMQP 0-9-1 Message Binding Object",
+  "description": "This object contains information about the message representation in AMQP.\nSee https://github.com/asyncapi/bindings/tree/master/amqp#message-binding-object.",
   "type": "object",
   "properties": {
     "contentEncoding": {

--- a/tests/resources/go/advanced/entities.go
+++ b/tests/resources/go/advanced/entities.go
@@ -27,8 +27,8 @@ type Properties struct {
 	Type                 *ShortStr              `json:"type,omitempty"`
 	UserID               *ShortStr              `json:"user-id,omitempty"`
 	AppID                *ShortStr              `json:"app-id,omitempty"`
-	MapOfAnythingValues  map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
-	AdditionalProperties map[string]Property    `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	AdditionalProperties map[string]Property    `json:"-"`                          // All unmatched properties
 }
 
 type marshalProperties Properties
@@ -55,7 +55,7 @@ func (i *Properties) UnmarshalJSON(data []byte) error {
 			"app-id",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		additionalProperties: &ii.AdditionalProperties,
 		jsonData: data,
@@ -69,7 +69,7 @@ func (i *Properties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Properties) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalProperties(i), i.MapOfAnythingValues, i.AdditionalProperties)
+	return marshalUnion(marshalProperties(i), i.MapOfAnything, i.AdditionalProperties)
 }
 
 // Table structure is generated from "#/definitions/table".

--- a/tests/resources/go/advanced/entities_test.go
+++ b/tests/resources/go/advanced/entities_test.go
@@ -14,7 +14,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 		MessageID: &ShortStr{
 			Value: "foo",
 		},
-		MapOfAnythingValues: map[string]interface{}{
+		MapOfAnything: map[string]interface{}{
 			"x-whatever": "hello!",
 		},
 		AdditionalProperties: map[string]Property{

--- a/tests/resources/go/asyncapi-data/entities_test.go
+++ b/tests/resources/go/asyncapi-data/entities_test.go
@@ -2,7 +2,7 @@ package entities
 
 import (
 	"encoding/json"
-	"reflect"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,16 +24,32 @@ func Test_MarshalUnmarshal(t *testing.T) {
 		SubscriptionID: 456,
 	}
 
-	j, err := json.Marshal(entity)
+	encodedJSON, err := json.Marshal(entity)
 	require.NoError(t, err)
-	assertjson.Equal(
-		t,
-		[]byte(`{"reads":[{"amount":100,"entity_id":"ISBN123","strategy":"fast","entity_type":"book","reason":"premium"}],"country":"US","reader_id":123,"week":"2008-W05","subscription_id":456}`),
-		j)
+
+	expectedJSON := []byte(`{
+  "reads": [
+    {
+      "amount": 100,
+      "entity_id": "ISBN123",
+      "strategy": "fast",
+      "entity_type": "book",
+      "reason": "premium"
+    }
+  ],
+  "country": "US",
+  "reader_id": 123,
+  "week": "2008-W05",
+  "subscription_id": 456
+}`)
+
+	assertjson.Equal(t, expectedJSON, encodedJSON)
 	decodedEntity := MessagingReaderReads{}
-	err = json.Unmarshal(j, &decodedEntity)
+	err = json.Unmarshal(encodedJSON, &decodedEntity)
 	require.NoError(t, err)
-	if !reflect.DeepEqual(entity, decodedEntity) {
-		t.Fatalf("not equal: %+v %+v", entity, decodedEntity)
-	}
+	assert.Equal(t, entity.Reads[0], decodedEntity.Reads[0])
+	//assert.Equal(t, entity, decodedEntity)
+	encodedJSON, err = json.Marshal(decodedEntity)
+	require.NoError(t, err)
+	assertjson.Equal(t, expectedJSON, encodedJSON)
 }

--- a/tests/resources/go/asyncapi-default/entities.go
+++ b/tests/resources/go/asyncapi-default/entities.go
@@ -15,18 +15,18 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi            Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
-	Info                *Info                  `json:"info,omitempty"`         // General information about the API.
-	BaseTopic           string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
-	Servers             []Server               `json:"servers,omitempty"`
-	Topics              *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
-	Stream              *Stream                `json:"stream,omitempty"`       // Stream Object
-	Events              *Events                `json:"events,omitempty"`       // Events Object
-	Components          *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
+	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
+	Servers       []Server               `json:"servers,omitempty"`
+	Topics        *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
+	Stream        *Stream                `json:"stream,omitempty"`       // Stream Object
+	Events        *Events                `json:"events,omitempty"`       // Events Object
+	Components    *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalAsyncAPI AsyncAPI
@@ -51,7 +51,7 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -64,20 +64,20 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i AsyncAPI) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/info".
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
@@ -97,7 +97,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"license",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -110,17 +110,17 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/contact".
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
@@ -137,7 +137,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -150,14 +150,14 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
@@ -173,7 +173,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -186,19 +186,19 @@ func (i *License) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // Server structure is generated from "#/definitions/server".
 //
 // An object representing a Server.
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Scheme              ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
-	SchemeVersion       string                    `json:"schemeVersion,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
+	URL           string                    `json:"url,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	Scheme        ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
+	SchemeVersion string                    `json:"schemeVersion,omitempty"`
+	Variables     map[string]ServerVariable `json:"variables,omitempty"`
+	MapOfAnything map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
 }
 
 type marshalServer Server
@@ -217,7 +217,7 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 			"variables",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -230,17 +230,17 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Server) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServer(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServer(i), i.MapOfAnything)
 }
 
 // ServerVariable structure is generated from "#/definitions/serverVariable".
 //
 // An object representing a Server Variable for server URL template substitution.
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServerVariable ServerVariable
@@ -257,7 +257,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -270,14 +270,14 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ServerVariable) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServerVariable(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServerVariable(i), i.MapOfAnything)
 }
 
 // Topics structure is generated from "#/definitions/topics".
 //
 // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
 type Topics struct {
-	MapOfAnythingValues  map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 	MapOfTopicItemValues map[string]TopicItem   `json:"-"` // Key must match pattern: ^[^.]
 }
 
@@ -288,7 +288,7 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 			regex: &i.MapOfTopicItemValues, // ^[^.]
 		},
 		jsonData: data,
@@ -299,17 +299,17 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Topics) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopics(i), i.MapOfAnythingValues, i.MapOfTopicItemValues)
+	return marshalUnion(marshalTopics(i), i.MapOfAnything, i.MapOfTopicItemValues)
 }
 
 // TopicItem structure is generated from "#/definitions/topicItem".
 type TopicItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Parameters          []Parameter            `json:"parameters,omitempty"`
-	Publish             *Operation             `json:"publish,omitempty"`
-	Subscribe           *Operation             `json:"subscribe,omitempty"`
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Parameters    []Parameter            `json:"parameters,omitempty"`
+	Publish       *Operation             `json:"publish,omitempty"`
+	Subscribe     *Operation             `json:"subscribe,omitempty"`
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalTopicItem TopicItem
@@ -328,7 +328,7 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 			"deprecated",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -341,16 +341,16 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i TopicItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopicItem(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTopicItem(i), i.MapOfAnything)
 }
 
 // Parameter structure is generated from "#/definitions/parameter".
 type Parameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                 `json:"name,omitempty"`        // The name of the parameter.
-	Schema              map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
-	Ref                 string                 `json:"$ref,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name          string                 `json:"name,omitempty"`        // The name of the parameter.
+	Schema        map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
+	Ref           string                 `json:"$ref,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
@@ -368,7 +368,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 			"$ref",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -381,21 +381,21 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything)
 }
 
 // Message structure is generated from "#/definitions/message".
 type Message struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Headers             map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
-	Payload             map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Summary             string                 `json:"summary,omitempty"`      // A brief summary of the message.
-	Description         string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Example             interface{}            `json:"example,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Headers       map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
+	Payload       map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`      // A brief summary of the message.
+	Description   string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Example       interface{}            `json:"example,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalMessage Message
@@ -418,7 +418,7 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 			"example",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -431,15 +431,15 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Message) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessage(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMessage(i), i.MapOfAnything)
 }
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
@@ -456,7 +456,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -469,16 +469,16 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // ExternalDocs structure is generated from "#/definitions/externalDocs".
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocs ExternalDocs
@@ -494,7 +494,7 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -507,13 +507,13 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocs) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocs(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocs(i), i.MapOfAnything)
 }
 
 // OperationOneOf1 structure is generated from "#/definitions/operation/oneOf/1".
 type OperationOneOf1 struct {
-	OneOf               []Message              `json:"oneOf,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	OneOf         []Message              `json:"oneOf,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalOperationOneOf1 OperationOneOf1
@@ -528,7 +528,7 @@ func (i *OperationOneOf1) UnmarshalJSON(data []byte) error {
 			"oneOf",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -541,7 +541,7 @@ func (i *OperationOneOf1) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OperationOneOf1) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnything)
 }
 
 // Operation structure is generated from "#/definitions/operation".
@@ -578,10 +578,10 @@ func (i Operation) MarshalJSON() ([]byte, error) {
 //
 // Stream Object.
 type Stream struct {
-	Framing             *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
-	Read                []Message              `json:"read,omitempty"`    // Stream Read Object
-	Write               []Message              `json:"write,omitempty"`   // Stream Write Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Framing       *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
+	Read          []Message              `json:"read,omitempty"`    // Stream Read Object
+	Write         []Message              `json:"write,omitempty"`   // Stream Write Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalStream Stream
@@ -598,7 +598,7 @@ func (i *Stream) UnmarshalJSON(data []byte) error {
 			"write",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -611,7 +611,7 @@ func (i *Stream) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Stream) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStream(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalStream(i), i.MapOfAnything)
 }
 
 // StreamFramingOneOf0 structure is generated from "#/definitions/stream->framing/oneOf/0".
@@ -690,9 +690,10 @@ func (i StreamFramingOneOf1) MarshalJSON() ([]byte, error) {
 //
 // Stream Framing Object.
 type StreamFraming struct {
-	OneOf0              *StreamFramingOneOf0   `json:"-"`
-	OneOf1              *StreamFramingOneOf1   `json:"-"`
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	OneOf0               *StreamFramingOneOf0   `json:"-"`
+	OneOf1               *StreamFramingOneOf1   `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalStreamFraming StreamFraming
@@ -703,8 +704,9 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if mayUnmarshal[0] == nil {
@@ -719,16 +721,16 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i StreamFraming) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStreamFraming(i), i.MapOfAnythingValues, i.OneOf0, i.OneOf1)
+	return marshalUnion(marshalStreamFraming(i), i.MapOfAnything, i.AdditionalProperties, i.OneOf0, i.OneOf1)
 }
 
 // Events structure is generated from "#/definitions/events".
 //
 // Events Object.
 type Events struct {
-	Receive             []Message              `json:"receive,omitempty"` // Events Receive Object
-	Send                []Message              `json:"send,omitempty"`    // Events Send Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Receive       []Message              `json:"receive,omitempty"` // Events Receive Object
+	Send          []Message              `json:"send,omitempty"`    // Events Send Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalEvents Events
@@ -744,7 +746,7 @@ func (i *Events) UnmarshalJSON(data []byte) error {
 			"send",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -757,7 +759,7 @@ func (i *Events) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Events) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalEvents(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalEvents(i), i.MapOfAnything)
 }
 
 // Components structure is generated from "#/definitions/components".
@@ -772,13 +774,40 @@ type Components struct {
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	Ref string `json:"$ref,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
+}
+
+type marshalReference Reference
+
+// UnmarshalJSON decodes JSON.
+func (i *Reference) UnmarshalJSON(data []byte) error {
+	ii := marshalReference(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$ref",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Reference(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Reference) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalReference(i), i.AdditionalProperties)
 }
 
 // UserPassword structure is generated from "#/definitions/userPassword".
 type UserPassword struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalUserPassword UserPassword
@@ -793,9 +822,10 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -816,14 +846,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i UserPassword) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnythingValues)
+	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnything)
 }
 
 // APIKey structure is generated from "#/definitions/apiKey".
 type APIKey struct {
-	In                  APIKeyIn               `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	In            APIKeyIn               `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKey APIKey
@@ -839,9 +869,10 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -862,13 +893,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKey) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnything)
 }
 
 // X509 structure is generated from "#/definitions/X509".
 type X509 struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalX509 X509
@@ -883,9 +914,10 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -906,13 +938,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i X509) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constX509, marshalX509(i), i.MapOfAnythingValues)
+	return marshalUnion(constX509, marshalX509(i), i.MapOfAnything)
 }
 
 // SymmetricEncryption structure is generated from "#/definitions/symmetricEncryption".
 type SymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalSymmetricEncryption SymmetricEncryption
@@ -927,9 +959,10 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -950,13 +983,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i SymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnything)
 }
 
 // AsymmetricEncryption structure is generated from "#/definitions/asymmetricEncryption".
 type AsymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAsymmetricEncryption AsymmetricEncryption
@@ -971,9 +1004,10 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -994,14 +1028,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i AsymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnything)
 }
 
 // NonBearerHTTPSecurityScheme structure is generated from "#/definitions/NonBearerHTTPSecurityScheme".
 type NonBearerHTTPSecurityScheme struct {
-	Scheme              string                 `json:"scheme,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Scheme        string                 `json:"scheme,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalNonBearerHTTPSecurityScheme NonBearerHTTPSecurityScheme
@@ -1017,9 +1051,10 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"scheme",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1040,14 +1075,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i NonBearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // BearerHTTPSecurityScheme structure is generated from "#/definitions/BearerHTTPSecurityScheme".
 type BearerHTTPSecurityScheme struct {
-	BearerFormat        string                 `json:"bearerFormat,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	BearerFormat  string                 `json:"bearerFormat,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalBearerHTTPSecurityScheme BearerHTTPSecurityScheme
@@ -1063,9 +1098,11 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"bearerFormat",
 			"description",
+			"scheme",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1089,15 +1126,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i BearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // APIKeyHTTPSecurityScheme structure is generated from "#/definitions/APIKeyHTTPSecurityScheme".
 type APIKeyHTTPSecurityScheme struct {
-	Name                string                     `json:"name,omitempty"`
-	In                  APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
-	Description         string                     `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
+	Name          string                     `json:"name,omitempty"`
+	In            APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
+	Description   string                     `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeyHTTPSecurityScheme APIKeyHTTPSecurityScheme
@@ -1114,9 +1151,10 @@ func (i *APIKeyHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"name",
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1137,7 +1175,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKeyHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // HTTPSecurityScheme structure is generated from "#/definitions/HTTPSecurityScheme".
@@ -1253,6 +1291,7 @@ func (i ComponentsSecuritySchemesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesAZAZ09Values map[string]ComponentsSecuritySchemesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                       map[string]interface{}                     `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
@@ -1264,6 +1303,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsSecuritySchemesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1272,7 +1312,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values)
+	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
 // Asyncapi is an enum type.
@@ -1575,11 +1615,12 @@ var (
 )
 
 type unionMap struct {
-	mustUnmarshal     []interface{}
-	mayUnmarshal      []interface{}
-	ignoreKeys        []string
-	patternProperties map[*regexp.Regexp]interface{}
-	jsonData          []byte
+	mustUnmarshal        []interface{}
+	mayUnmarshal         []interface{}
+	ignoreKeys           []string
+	patternProperties    map[*regexp.Regexp]interface{}
+	additionalProperties interface{}
+	jsonData             []byte
 }
 
 func (u unionMap) unmarshal() error {
@@ -1597,10 +1638,10 @@ func (u unionMap) unmarshal() error {
 			u.mayUnmarshal[i] = nil
 		}
 	}
-	if len(u.patternProperties) == 0 {
+
+	if len(u.patternProperties) == 0 && u.additionalProperties == nil {
 		return nil
 	}
-
 	// unmarshal to a generic map
 	var m map[string]*json.RawMessage
 	err := json.Unmarshal(u.jsonData, &m)
@@ -1625,10 +1666,35 @@ func (u unionMap) unmarshal() error {
 	if len(m) == 0 {
 		return nil
 	}
-
+	if u.additionalProperties != nil {
+		return u.unmarshalAdditionalProperties(m)
+	}
 	return nil
 }
+func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) error {
+	var err error
+	subMap := make([]byte, 1, 100)
+	subMap[0] = '{'
 
+	// Iterating map and filling additional properties.
+	for key, val := range m {
+		keyEscaped := `"` + strings.Replace(key, `"`, `\"`, -1) + `":`
+		if len(subMap) != 1 {
+			subMap = append(subMap[:len(subMap)-1], ',')
+		}
+		subMap = append(subMap, []byte(keyEscaped)...)
+		subMap = append(subMap, []byte(*val)...)
+		subMap = append(subMap, '}')
+	}
+
+	if len(subMap) > 1 {
+		err = json.Unmarshal(subMap, u.additionalProperties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) error {
 	patternMapsRaw := make(map[*regexp.Regexp][]byte, len(u.patternProperties))
 	// Iterating map and filling pattern properties sub maps.

--- a/tests/resources/go/asyncapi-default/entities_test.go
+++ b/tests/resources/go/asyncapi-default/entities_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/swaggest/assertjson"
 )
@@ -25,7 +24,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 				},
 			},
 		},
-		MapOfAnythingValues: map[string]interface{}{
+		MapOfAnything: map[string]interface{}{
 			"x-whatever": "hello!",
 		},
 	}
@@ -41,7 +40,7 @@ func Test_MarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	anotherData, err := json.Marshal(unmarshaled)
 	require.NoError(t, err)
-	assert.Equal(t, string(data), string(anotherData))
+	assertjson.Equal(t, data, anotherData)
 }
 
 func Benchmark_Marshal(b *testing.B) {
@@ -62,7 +61,7 @@ func Benchmark_Marshal(b *testing.B) {
 					},
 				},
 			},
-			MapOfAnythingValues: map[string]interface{}{
+			MapOfAnything: map[string]interface{}{
 				"x-whatever": "hello!",
 			},
 		}

--- a/tests/resources/go/asyncapi-skip-marshal/entities.go
+++ b/tests/resources/go/asyncapi-skip-marshal/entities.go
@@ -13,18 +13,18 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi            Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
-	Info                *Info                  `json:"info,omitempty"`         // General information about the API.
-	BaseTopic           string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
-	Servers             []Server               `json:"servers,omitempty"`
-	Topics              *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
-	Stream              *Stream                `json:"stream,omitempty"`       // Stream Object
-	Events              *Events                `json:"events,omitempty"`       // Events Object
-	Components          *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
+	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
+	Servers       []Server               `json:"servers,omitempty"`
+	Topics        *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
+	Stream        *Stream                `json:"stream,omitempty"`       // Stream Object
+	Events        *Events                `json:"events,omitempty"`       // Events Object
+	Components    *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalAsyncAPI AsyncAPI
@@ -49,7 +49,7 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -65,13 +65,13 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
@@ -91,7 +91,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"license",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -107,10 +107,10 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
@@ -127,7 +127,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -141,9 +141,9 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
@@ -159,7 +159,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -175,12 +175,12 @@ func (i *License) UnmarshalJSON(data []byte) error {
 //
 // An object representing a Server.
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Scheme              ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
-	SchemeVersion       string                    `json:"schemeVersion,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
+	URL           string                    `json:"url,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	Scheme        ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
+	SchemeVersion string                    `json:"schemeVersion,omitempty"`
+	Variables     map[string]ServerVariable `json:"variables,omitempty"`
+	MapOfAnything map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
 }
 
 type marshalServer Server
@@ -199,7 +199,7 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 			"variables",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -215,10 +215,10 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 //
 // An object representing a Server Variable for server URL template substitution.
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServerVariable ServerVariable
@@ -235,7 +235,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -251,7 +251,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 //
 // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
 type Topics struct {
-	MapOfAnythingValues  map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 	MapOfTopicItemValues map[string]TopicItem   `json:"-"` // Key must match pattern: ^[^.]
 }
 
@@ -262,7 +262,7 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 			regex: &i.MapOfTopicItemValues, // ^[^.]
 		},
 		jsonData: data,
@@ -274,12 +274,12 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 // TopicItem structure is generated from "#/definitions/topicItem".
 type TopicItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Parameters          []Parameter            `json:"parameters,omitempty"`
-	Publish             *Operation             `json:"publish,omitempty"`
-	Subscribe           *Operation             `json:"subscribe,omitempty"`
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Parameters    []Parameter            `json:"parameters,omitempty"`
+	Publish       *Operation             `json:"publish,omitempty"`
+	Subscribe     *Operation             `json:"subscribe,omitempty"`
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalTopicItem TopicItem
@@ -298,7 +298,7 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 			"deprecated",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -312,11 +312,11 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 
 // Parameter structure is generated from "#/definitions/parameter".
 type Parameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                 `json:"name,omitempty"`        // The name of the parameter.
-	Schema              map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
-	Ref                 string                 `json:"$ref,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name          string                 `json:"name,omitempty"`        // The name of the parameter.
+	Schema        map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
+	Ref           string                 `json:"$ref,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
@@ -334,7 +334,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 			"$ref",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -348,16 +348,16 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // Message structure is generated from "#/definitions/message".
 type Message struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Headers             map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
-	Payload             map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Summary             string                 `json:"summary,omitempty"`      // A brief summary of the message.
-	Description         string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Example             interface{}            `json:"example,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Headers       map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
+	Payload       map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`      // A brief summary of the message.
+	Description   string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Example       interface{}            `json:"example,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalMessage Message
@@ -380,7 +380,7 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 			"example",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -394,10 +394,10 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
@@ -414,7 +414,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -430,9 +430,9 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocs ExternalDocs
@@ -448,7 +448,7 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -462,8 +462,8 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 
 // OperationOneOf1 structure is generated from "#/definitions/operation/oneOf/1".
 type OperationOneOf1 struct {
-	OneOf               []Message              `json:"oneOf,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	OneOf         []Message              `json:"oneOf,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalOperationOneOf1 OperationOneOf1
@@ -478,7 +478,7 @@ func (i *OperationOneOf1) UnmarshalJSON(data []byte) error {
 			"oneOf",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -520,10 +520,10 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 //
 // Stream Object.
 type Stream struct {
-	Framing             *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
-	Read                []Message              `json:"read,omitempty"`    // Stream Read Object
-	Write               []Message              `json:"write,omitempty"`   // Stream Write Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Framing       *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
+	Read          []Message              `json:"read,omitempty"`    // Stream Read Object
+	Write         []Message              `json:"write,omitempty"`   // Stream Write Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalStream Stream
@@ -540,7 +540,7 @@ func (i *Stream) UnmarshalJSON(data []byte) error {
 			"write",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -610,9 +610,10 @@ func (i *StreamFramingOneOf1) UnmarshalJSON(data []byte) error {
 //
 // Stream Framing Object.
 type StreamFraming struct {
-	OneOf0              *StreamFramingOneOf0   `json:"-"`
-	OneOf1              *StreamFramingOneOf1   `json:"-"`
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	OneOf0               *StreamFramingOneOf0   `json:"-"`
+	OneOf1               *StreamFramingOneOf1   `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalStreamFraming StreamFraming
@@ -623,8 +624,9 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if mayUnmarshal[0] == nil {
@@ -642,9 +644,9 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 //
 // Events Object.
 type Events struct {
-	Receive             []Message              `json:"receive,omitempty"` // Events Receive Object
-	Send                []Message              `json:"send,omitempty"`    // Events Send Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Receive       []Message              `json:"receive,omitempty"` // Events Receive Object
+	Send          []Message              `json:"send,omitempty"`    // Events Send Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalEvents Events
@@ -660,7 +662,7 @@ func (i *Events) UnmarshalJSON(data []byte) error {
 			"send",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -684,13 +686,36 @@ type Components struct {
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	Ref string `json:"$ref,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
 }
+
+type marshalReference Reference
+
+// UnmarshalJSON decodes JSON.
+func (i *Reference) UnmarshalJSON(data []byte) error {
+	ii := marshalReference(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$ref",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Reference(ii)
+	return err
+}
+
 
 // UserPassword structure is generated from "#/definitions/userPassword".
 type UserPassword struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalUserPassword UserPassword
@@ -705,9 +730,10 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -724,9 +750,9 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 
 // APIKey structure is generated from "#/definitions/apiKey".
 type APIKey struct {
-	In                  APIKeyIn               `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	In            APIKeyIn               `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKey APIKey
@@ -742,9 +768,10 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -761,8 +788,8 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 
 // X509 structure is generated from "#/definitions/X509".
 type X509 struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalX509 X509
@@ -777,9 +804,10 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -796,8 +824,8 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 
 // SymmetricEncryption structure is generated from "#/definitions/symmetricEncryption".
 type SymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalSymmetricEncryption SymmetricEncryption
@@ -812,9 +840,10 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -831,8 +860,8 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 
 // AsymmetricEncryption structure is generated from "#/definitions/asymmetricEncryption".
 type AsymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAsymmetricEncryption AsymmetricEncryption
@@ -847,9 +876,10 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -866,9 +896,9 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 
 // NonBearerHTTPSecurityScheme structure is generated from "#/definitions/NonBearerHTTPSecurityScheme".
 type NonBearerHTTPSecurityScheme struct {
-	Scheme              string                 `json:"scheme,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Scheme        string                 `json:"scheme,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalNonBearerHTTPSecurityScheme NonBearerHTTPSecurityScheme
@@ -884,9 +914,10 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"scheme",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -903,9 +934,9 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 
 // BearerHTTPSecurityScheme structure is generated from "#/definitions/BearerHTTPSecurityScheme".
 type BearerHTTPSecurityScheme struct {
-	BearerFormat        string                 `json:"bearerFormat,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	BearerFormat  string                 `json:"bearerFormat,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalBearerHTTPSecurityScheme BearerHTTPSecurityScheme
@@ -921,9 +952,11 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"bearerFormat",
 			"description",
+			"scheme",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -943,10 +976,10 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 
 // APIKeyHTTPSecurityScheme structure is generated from "#/definitions/APIKeyHTTPSecurityScheme".
 type APIKeyHTTPSecurityScheme struct {
-	Name                string                     `json:"name,omitempty"`
-	In                  APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
-	Description         string                     `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
+	Name          string                     `json:"name,omitempty"`
+	In            APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
+	Description   string                     `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeyHTTPSecurityScheme APIKeyHTTPSecurityScheme
@@ -963,9 +996,10 @@ func (i *APIKeyHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"name",
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1081,6 +1115,7 @@ func (i *ComponentsSecuritySchemesAZAZ09) UnmarshalJSON(data []byte) error {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesAZAZ09Values map[string]ComponentsSecuritySchemesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                       map[string]interface{}                     `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
@@ -1092,6 +1127,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsSecuritySchemesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1280,11 +1316,12 @@ var (
 )
 
 type unionMap struct {
-	mustUnmarshal     []interface{}
-	mayUnmarshal      []interface{}
-	ignoreKeys        []string
-	patternProperties map[*regexp.Regexp]interface{}
-	jsonData          []byte
+	mustUnmarshal        []interface{}
+	mayUnmarshal         []interface{}
+	ignoreKeys           []string
+	patternProperties    map[*regexp.Regexp]interface{}
+	additionalProperties interface{}
+	jsonData             []byte
 }
 
 func (u unionMap) unmarshal() error {
@@ -1302,10 +1339,10 @@ func (u unionMap) unmarshal() error {
 			u.mayUnmarshal[i] = nil
 		}
 	}
-	if len(u.patternProperties) == 0 {
+
+	if len(u.patternProperties) == 0 && u.additionalProperties == nil {
 		return nil
 	}
-
 	// unmarshal to a generic map
 	var m map[string]*json.RawMessage
 	err := json.Unmarshal(u.jsonData, &m)
@@ -1330,10 +1367,35 @@ func (u unionMap) unmarshal() error {
 	if len(m) == 0 {
 		return nil
 	}
-
+	if u.additionalProperties != nil {
+		return u.unmarshalAdditionalProperties(m)
+	}
 	return nil
 }
+func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) error {
+	var err error
+	subMap := make([]byte, 1, 100)
+	subMap[0] = '{'
 
+	// Iterating map and filling additional properties.
+	for key, val := range m {
+		keyEscaped := `"` + strings.Replace(key, `"`, `\"`, -1) + `":`
+		if len(subMap) != 1 {
+			subMap = append(subMap[:len(subMap)-1], ',')
+		}
+		subMap = append(subMap, []byte(keyEscaped)...)
+		subMap = append(subMap, []byte(*val)...)
+		subMap = append(subMap, '}')
+	}
+
+	if len(subMap) > 1 {
+		err = json.Unmarshal(subMap, u.additionalProperties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) error {
 	patternMapsRaw := make(map[*regexp.Regexp][]byte, len(u.patternProperties))
 	// Iterating map and filling pattern properties sub maps.

--- a/tests/resources/go/asyncapi-skip-unmarshal/entities.go
+++ b/tests/resources/go/asyncapi-skip-unmarshal/entities.go
@@ -13,119 +13,119 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi            Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
-	Info                *Info                  `json:"info,omitempty"`         // General information about the API.
-	BaseTopic           string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
-	Servers             []Server               `json:"servers,omitempty"`
-	Topics              *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
-	Stream              *Stream                `json:"stream,omitempty"`       // Stream Object
-	Events              *Events                `json:"events,omitempty"`       // Events Object
-	Components          *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
+	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
+	Servers       []Server               `json:"servers,omitempty"`
+	Topics        *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
+	Stream        *Stream                `json:"stream,omitempty"`       // Stream Object
+	Events        *Events                `json:"events,omitempty"`       // Events Object
+	Components    *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalAsyncAPI AsyncAPI
 
 // MarshalJSON encodes JSON.
 func (i AsyncAPI) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/info".
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/contact".
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // Server structure is generated from "#/definitions/server".
 //
 // An object representing a Server.
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Scheme              ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
-	SchemeVersion       string                    `json:"schemeVersion,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
+	URL           string                    `json:"url,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	Scheme        ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
+	SchemeVersion string                    `json:"schemeVersion,omitempty"`
+	Variables     map[string]ServerVariable `json:"variables,omitempty"`
+	MapOfAnything map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
 }
 
 type marshalServer Server
 
 // MarshalJSON encodes JSON.
 func (i Server) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServer(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServer(i), i.MapOfAnything)
 }
 
 // ServerVariable structure is generated from "#/definitions/serverVariable".
 //
 // An object representing a Server Variable for server URL template substitution.
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServerVariable ServerVariable
 
 // MarshalJSON encodes JSON.
 func (i ServerVariable) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServerVariable(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServerVariable(i), i.MapOfAnything)
 }
 
 // Topics structure is generated from "#/definitions/topics".
 //
 // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
 type Topics struct {
-	MapOfAnythingValues  map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 	MapOfTopicItemValues map[string]TopicItem   `json:"-"` // Key must match pattern: ^[^.]
 }
 
@@ -133,105 +133,105 @@ type marshalTopics Topics
 
 // MarshalJSON encodes JSON.
 func (i Topics) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopics(i), i.MapOfAnythingValues, i.MapOfTopicItemValues)
+	return marshalUnion(marshalTopics(i), i.MapOfAnything, i.MapOfTopicItemValues)
 }
 
 // TopicItem structure is generated from "#/definitions/topicItem".
 type TopicItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Parameters          []Parameter            `json:"parameters,omitempty"`
-	Publish             *Operation             `json:"publish,omitempty"`
-	Subscribe           *Operation             `json:"subscribe,omitempty"`
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Parameters    []Parameter            `json:"parameters,omitempty"`
+	Publish       *Operation             `json:"publish,omitempty"`
+	Subscribe     *Operation             `json:"subscribe,omitempty"`
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalTopicItem TopicItem
 
 // MarshalJSON encodes JSON.
 func (i TopicItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopicItem(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTopicItem(i), i.MapOfAnything)
 }
 
 // Parameter structure is generated from "#/definitions/parameter".
 type Parameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                 `json:"name,omitempty"`        // The name of the parameter.
-	Schema              map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
-	Ref                 string                 `json:"$ref,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name          string                 `json:"name,omitempty"`        // The name of the parameter.
+	Schema        map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
+	Ref           string                 `json:"$ref,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything)
 }
 
 // Message structure is generated from "#/definitions/message".
 type Message struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Headers             map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
-	Payload             map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Summary             string                 `json:"summary,omitempty"`      // A brief summary of the message.
-	Description         string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Example             interface{}            `json:"example,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Headers       map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
+	Payload       map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`      // A brief summary of the message.
+	Description   string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Example       interface{}            `json:"example,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalMessage Message
 
 // MarshalJSON encodes JSON.
 func (i Message) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessage(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMessage(i), i.MapOfAnything)
 }
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // ExternalDocs structure is generated from "#/definitions/externalDocs".
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocs ExternalDocs
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocs) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocs(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocs(i), i.MapOfAnything)
 }
 
 // OperationOneOf1 structure is generated from "#/definitions/operation/oneOf/1".
 type OperationOneOf1 struct {
-	OneOf               []Message              `json:"oneOf,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	OneOf         []Message              `json:"oneOf,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalOperationOneOf1 OperationOneOf1
 
 // MarshalJSON encodes JSON.
 func (i OperationOneOf1) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnything)
 }
 
 // Operation structure is generated from "#/definitions/operation".
@@ -251,17 +251,17 @@ func (i Operation) MarshalJSON() ([]byte, error) {
 //
 // Stream Object.
 type Stream struct {
-	Framing             *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
-	Read                []Message              `json:"read,omitempty"`    // Stream Read Object
-	Write               []Message              `json:"write,omitempty"`   // Stream Write Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Framing       *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
+	Read          []Message              `json:"read,omitempty"`    // Stream Read Object
+	Write         []Message              `json:"write,omitempty"`   // Stream Write Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalStream Stream
 
 // MarshalJSON encodes JSON.
 func (i Stream) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStream(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalStream(i), i.MapOfAnything)
 }
 
 // StreamFramingOneOf0 structure is generated from "#/definitions/stream->framing/oneOf/0".
@@ -302,32 +302,33 @@ func (i StreamFramingOneOf1) MarshalJSON() ([]byte, error) {
 //
 // Stream Framing Object.
 type StreamFraming struct {
-	OneOf0              *StreamFramingOneOf0   `json:"-"`
-	OneOf1              *StreamFramingOneOf1   `json:"-"`
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	OneOf0               *StreamFramingOneOf0   `json:"-"`
+	OneOf1               *StreamFramingOneOf1   `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalStreamFraming StreamFraming
 
 // MarshalJSON encodes JSON.
 func (i StreamFraming) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStreamFraming(i), i.MapOfAnythingValues, i.OneOf0, i.OneOf1)
+	return marshalUnion(marshalStreamFraming(i), i.MapOfAnything, i.AdditionalProperties, i.OneOf0, i.OneOf1)
 }
 
 // Events structure is generated from "#/definitions/events".
 //
 // Events Object.
 type Events struct {
-	Receive             []Message              `json:"receive,omitempty"` // Events Receive Object
-	Send                []Message              `json:"send,omitempty"`    // Events Send Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Receive       []Message              `json:"receive,omitempty"` // Events Receive Object
+	Send          []Message              `json:"send,omitempty"`    // Events Send Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalEvents Events
 
 // MarshalJSON encodes JSON.
 func (i Events) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalEvents(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalEvents(i), i.MapOfAnything)
 }
 
 // Components structure is generated from "#/definitions/components".
@@ -342,13 +343,21 @@ type Components struct {
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	Ref string `json:"$ref,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
+}
+
+type marshalReference Reference
+
+// MarshalJSON encodes JSON.
+func (i Reference) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalReference(i), i.AdditionalProperties)
 }
 
 // UserPassword structure is generated from "#/definitions/userPassword".
 type UserPassword struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalUserPassword UserPassword
@@ -360,14 +369,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i UserPassword) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnythingValues)
+	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnything)
 }
 
 // APIKey structure is generated from "#/definitions/apiKey".
 type APIKey struct {
-	In                  APIKeyIn               `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	In            APIKeyIn               `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKey APIKey
@@ -379,13 +388,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKey) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnything)
 }
 
 // X509 structure is generated from "#/definitions/X509".
 type X509 struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalX509 X509
@@ -397,13 +406,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i X509) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constX509, marshalX509(i), i.MapOfAnythingValues)
+	return marshalUnion(constX509, marshalX509(i), i.MapOfAnything)
 }
 
 // SymmetricEncryption structure is generated from "#/definitions/symmetricEncryption".
 type SymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalSymmetricEncryption SymmetricEncryption
@@ -415,13 +424,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i SymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnything)
 }
 
 // AsymmetricEncryption structure is generated from "#/definitions/asymmetricEncryption".
 type AsymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAsymmetricEncryption AsymmetricEncryption
@@ -433,14 +442,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i AsymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnything)
 }
 
 // NonBearerHTTPSecurityScheme structure is generated from "#/definitions/NonBearerHTTPSecurityScheme".
 type NonBearerHTTPSecurityScheme struct {
-	Scheme              string                 `json:"scheme,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Scheme        string                 `json:"scheme,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalNonBearerHTTPSecurityScheme NonBearerHTTPSecurityScheme
@@ -452,14 +461,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i NonBearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // BearerHTTPSecurityScheme structure is generated from "#/definitions/BearerHTTPSecurityScheme".
 type BearerHTTPSecurityScheme struct {
-	BearerFormat        string                 `json:"bearerFormat,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	BearerFormat  string                 `json:"bearerFormat,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalBearerHTTPSecurityScheme BearerHTTPSecurityScheme
@@ -471,15 +480,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i BearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // APIKeyHTTPSecurityScheme structure is generated from "#/definitions/APIKeyHTTPSecurityScheme".
 type APIKeyHTTPSecurityScheme struct {
-	Name                string                     `json:"name,omitempty"`
-	In                  APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
-	Description         string                     `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
+	Name          string                     `json:"name,omitempty"`
+	In            APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
+	Description   string                     `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeyHTTPSecurityScheme APIKeyHTTPSecurityScheme
@@ -491,7 +500,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKeyHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // HTTPSecurityScheme structure is generated from "#/definitions/HTTPSecurityScheme".
@@ -541,13 +550,14 @@ func (i ComponentsSecuritySchemesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesAZAZ09Values map[string]ComponentsSecuritySchemesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                       map[string]interface{}                     `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values)
+	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
 // Asyncapi is an enum type.

--- a/tests/resources/go/asyncapi/entities.go
+++ b/tests/resources/go/asyncapi/entities.go
@@ -15,18 +15,18 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi            Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
-	Info                *Info                  `json:"info,omitempty"`         // General information about the API.
-	BaseTopic           string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
-	Servers             []Server               `json:"servers,omitempty"`
-	Topics              *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
-	Stream              *Stream                `json:"stream,omitempty"`       // Stream Object
-	Events              *Events                `json:"events,omitempty"`       // Events Object
-	Components          *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
+	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
+	Servers       []Server               `json:"servers,omitempty"`
+	Topics        *Topics                `json:"topics,omitempty"`       // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
+	Stream        *Stream                `json:"stream,omitempty"`       // Stream Object
+	Events        *Events                `json:"events,omitempty"`       // Events Object
+	Components    *Components            `json:"components,omitempty"`   // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalAsyncAPI AsyncAPI
@@ -51,7 +51,7 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -64,20 +64,20 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i AsyncAPI) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAsyncAPI(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/info".
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
@@ -97,7 +97,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"license",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -110,17 +110,17 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/contact".
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
@@ -137,7 +137,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -150,14 +150,14 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
@@ -173,7 +173,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -186,19 +186,19 @@ func (i *License) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // Server structure is generated from "#/definitions/server".
 //
 // An object representing a Server.
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Scheme              ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
-	SchemeVersion       string                    `json:"schemeVersion,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
+	URL           string                    `json:"url,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	Scheme        ServerScheme              `json:"scheme,omitempty"`        // The transfer protocol.
+	SchemeVersion string                    `json:"schemeVersion,omitempty"`
+	Variables     map[string]ServerVariable `json:"variables,omitempty"`
+	MapOfAnything map[string]interface{}    `json:"-"`                       // Key must match pattern: ^x-
 }
 
 type marshalServer Server
@@ -217,7 +217,7 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 			"variables",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -230,17 +230,17 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Server) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServer(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServer(i), i.MapOfAnything)
 }
 
 // ServerVariable structure is generated from "#/definitions/serverVariable".
 //
 // An object representing a Server Variable for server URL template substitution.
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServerVariable ServerVariable
@@ -257,7 +257,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -270,14 +270,14 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ServerVariable) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServerVariable(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServerVariable(i), i.MapOfAnything)
 }
 
 // Topics structure is generated from "#/definitions/topics".
 //
 // Relative paths to the individual topics. They must be relative to the 'baseTopic'.
 type Topics struct {
-	MapOfAnythingValues  map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 	MapOfTopicItemValues map[string]TopicItem   `json:"-"` // Key must match pattern: ^[^.]
 }
 
@@ -288,7 +288,7 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 			regex: &i.MapOfTopicItemValues, // ^[^.]
 		},
 		jsonData: data,
@@ -299,17 +299,17 @@ func (i *Topics) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Topics) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopics(i), i.MapOfAnythingValues, i.MapOfTopicItemValues)
+	return marshalUnion(marshalTopics(i), i.MapOfAnything, i.MapOfTopicItemValues)
 }
 
 // TopicItem structure is generated from "#/definitions/topicItem".
 type TopicItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Parameters          []Parameter            `json:"parameters,omitempty"`
-	Publish             *Operation             `json:"publish,omitempty"`
-	Subscribe           *Operation             `json:"subscribe,omitempty"`
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Parameters    []Parameter            `json:"parameters,omitempty"`
+	Publish       *Operation             `json:"publish,omitempty"`
+	Subscribe     *Operation             `json:"subscribe,omitempty"`
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalTopicItem TopicItem
@@ -328,7 +328,7 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 			"deprecated",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -341,16 +341,16 @@ func (i *TopicItem) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i TopicItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTopicItem(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTopicItem(i), i.MapOfAnything)
 }
 
 // Parameter structure is generated from "#/definitions/parameter".
 type Parameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                 `json:"name,omitempty"`        // The name of the parameter.
-	Schema              map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
-	Ref                 string                 `json:"$ref,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name          string                 `json:"name,omitempty"`        // The name of the parameter.
+	Schema        map[string]interface{} `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
+	Ref           string                 `json:"$ref,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
@@ -368,7 +368,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 			"$ref",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -381,21 +381,21 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything)
 }
 
 // Message structure is generated from "#/definitions/message".
 type Message struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Headers             map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
-	Payload             map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Summary             string                 `json:"summary,omitempty"`      // A brief summary of the message.
-	Description         string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Example             interface{}            `json:"example,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Headers       map[string]interface{} `json:"headers,omitempty"`      // A deterministic version of a JSON Schema object.
+	Payload       map[string]interface{} `json:"payload,omitempty"`      // A deterministic version of a JSON Schema object.
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`      // A brief summary of the message.
+	Description   string                 `json:"description,omitempty"`  // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Example       interface{}            `json:"example,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalMessage Message
@@ -418,7 +418,7 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 			"example",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -431,15 +431,15 @@ func (i *Message) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Message) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessage(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMessage(i), i.MapOfAnything)
 }
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
@@ -456,7 +456,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -469,16 +469,16 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // ExternalDocs structure is generated from "#/definitions/externalDocs".
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocs ExternalDocs
@@ -494,7 +494,7 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -507,13 +507,13 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocs) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocs(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocs(i), i.MapOfAnything)
 }
 
 // OperationOneOf1 structure is generated from "#/definitions/operation/oneOf/1".
 type OperationOneOf1 struct {
-	OneOf               []Message              `json:"oneOf,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	OneOf         []Message              `json:"oneOf,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalOperationOneOf1 OperationOneOf1
@@ -528,7 +528,7 @@ func (i *OperationOneOf1) UnmarshalJSON(data []byte) error {
 			"oneOf",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -541,7 +541,7 @@ func (i *OperationOneOf1) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OperationOneOf1) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperationOneOf1(i), i.MapOfAnything)
 }
 
 // Operation structure is generated from "#/definitions/operation".
@@ -578,10 +578,10 @@ func (i Operation) MarshalJSON() ([]byte, error) {
 //
 // Stream Object.
 type Stream struct {
-	Framing             *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
-	Read                []Message              `json:"read,omitempty"`    // Stream Read Object
-	Write               []Message              `json:"write,omitempty"`   // Stream Write Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Framing       *StreamFraming         `json:"framing,omitempty"` // Stream Framing Object
+	Read          []Message              `json:"read,omitempty"`    // Stream Read Object
+	Write         []Message              `json:"write,omitempty"`   // Stream Write Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalStream Stream
@@ -598,7 +598,7 @@ func (i *Stream) UnmarshalJSON(data []byte) error {
 			"write",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -611,7 +611,7 @@ func (i *Stream) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Stream) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStream(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalStream(i), i.MapOfAnything)
 }
 
 // StreamFramingOneOf0 structure is generated from "#/definitions/stream->framing/oneOf/0".
@@ -630,9 +630,10 @@ type StreamFramingOneOf1 struct {
 //
 // Stream Framing Object.
 type StreamFraming struct {
-	StreamFramingOneOf0 *StreamFramingOneOf0   `json:"-"`
-	StreamFramingOneOf1 *StreamFramingOneOf1   `json:"-"`
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	StreamFramingOneOf0  *StreamFramingOneOf0   `json:"-"`
+	StreamFramingOneOf1  *StreamFramingOneOf1   `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalStreamFraming StreamFraming
@@ -643,8 +644,9 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if mayUnmarshal[0] == nil {
@@ -659,16 +661,16 @@ func (i *StreamFraming) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i StreamFraming) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalStreamFraming(i), i.MapOfAnythingValues, i.StreamFramingOneOf0, i.StreamFramingOneOf1)
+	return marshalUnion(marshalStreamFraming(i), i.MapOfAnything, i.AdditionalProperties, i.StreamFramingOneOf0, i.StreamFramingOneOf1)
 }
 
 // Events structure is generated from "#/definitions/events".
 //
 // Events Object.
 type Events struct {
-	Receive             []Message              `json:"receive,omitempty"` // Events Receive Object
-	Send                []Message              `json:"send,omitempty"`    // Events Send Object
-	MapOfAnythingValues map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
+	Receive       []Message              `json:"receive,omitempty"` // Events Receive Object
+	Send          []Message              `json:"send,omitempty"`    // Events Send Object
+	MapOfAnything map[string]interface{} `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalEvents Events
@@ -684,7 +686,7 @@ func (i *Events) UnmarshalJSON(data []byte) error {
 			"send",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -697,7 +699,7 @@ func (i *Events) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Events) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalEvents(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalEvents(i), i.MapOfAnything)
 }
 
 // Components structure is generated from "#/definitions/components".
@@ -712,14 +714,41 @@ type Components struct {
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	Ref string `json:"$ref,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
+}
+
+type marshalReference Reference
+
+// UnmarshalJSON decodes JSON.
+func (i *Reference) UnmarshalJSON(data []byte) error {
+	ii := marshalReference(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$ref",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Reference(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Reference) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalReference(i), i.AdditionalProperties)
 }
 
 // UserPassword structure is generated from "#/definitions/userPassword".
 type UserPassword struct {
-	Type                UserPasswordType       `json:"type,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Type          UserPasswordType       `json:"type,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalUserPassword UserPassword
@@ -735,7 +764,7 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -748,15 +777,15 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i UserPassword) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalUserPassword(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalUserPassword(i), i.MapOfAnything)
 }
 
 // APIKey structure is generated from "#/definitions/apiKey".
 type APIKey struct {
-	Type                APIKeyType             `json:"type,omitempty"`
-	In                  APIKeyIn               `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Type          APIKeyType             `json:"type,omitempty"`
+	In            APIKeyIn               `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKey APIKey
@@ -773,7 +802,7 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -786,14 +815,14 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i APIKey) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAPIKey(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAPIKey(i), i.MapOfAnything)
 }
 
 // X509 structure is generated from "#/definitions/X509".
 type X509 struct {
-	Type                X509Type               `json:"type,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Type          X509Type               `json:"type,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalX509 X509
@@ -809,7 +838,7 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -822,14 +851,14 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i X509) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalX509(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalX509(i), i.MapOfAnything)
 }
 
 // SymmetricEncryption structure is generated from "#/definitions/symmetricEncryption".
 type SymmetricEncryption struct {
-	Type                SymmetricEncryptionType `json:"type,omitempty"`
-	Description         string                  `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}  `json:"-"`                     // Key must match pattern: ^x-
+	Type          SymmetricEncryptionType `json:"type,omitempty"`
+	Description   string                  `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}  `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalSymmetricEncryption SymmetricEncryption
@@ -845,7 +874,7 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -858,14 +887,14 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i SymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalSymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalSymmetricEncryption(i), i.MapOfAnything)
 }
 
 // AsymmetricEncryption structure is generated from "#/definitions/asymmetricEncryption".
 type AsymmetricEncryption struct {
-	Type                AsymmetricEncryptionType `json:"type,omitempty"`
-	Description         string                   `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}   `json:"-"`                     // Key must match pattern: ^x-
+	Type          AsymmetricEncryptionType `json:"type,omitempty"`
+	Description   string                   `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}   `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAsymmetricEncryption AsymmetricEncryption
@@ -881,7 +910,7 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -894,15 +923,15 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i AsymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAsymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAsymmetricEncryption(i), i.MapOfAnything)
 }
 
 // NonBearerHTTPSecurityScheme structure is generated from "#/definitions/NonBearerHTTPSecurityScheme".
 type NonBearerHTTPSecurityScheme struct {
-	Scheme              string                          `json:"scheme,omitempty"`
-	Description         string                          `json:"description,omitempty"`
-	Type                NonBearerHTTPSecuritySchemeType `json:"type,omitempty"`
-	MapOfAnythingValues map[string]interface{}          `json:"-"`                     // Key must match pattern: ^x-
+	Scheme        string                          `json:"scheme,omitempty"`
+	Description   string                          `json:"description,omitempty"`
+	Type          NonBearerHTTPSecuritySchemeType `json:"type,omitempty"`
+	MapOfAnything map[string]interface{}          `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalNonBearerHTTPSecurityScheme NonBearerHTTPSecurityScheme
@@ -919,7 +948,7 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -932,16 +961,16 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i NonBearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // BearerHTTPSecurityScheme structure is generated from "#/definitions/BearerHTTPSecurityScheme".
 type BearerHTTPSecurityScheme struct {
-	Scheme              BearerHTTPSecuritySchemeScheme `json:"scheme,omitempty"`
-	BearerFormat        string                         `json:"bearerFormat,omitempty"`
-	Type                BearerHTTPSecuritySchemeType   `json:"type,omitempty"`
-	Description         string                         `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}         `json:"-"`                      // Key must match pattern: ^x-
+	Scheme        BearerHTTPSecuritySchemeScheme `json:"scheme,omitempty"`
+	BearerFormat  string                         `json:"bearerFormat,omitempty"`
+	Type          BearerHTTPSecuritySchemeType   `json:"type,omitempty"`
+	Description   string                         `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}         `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalBearerHTTPSecurityScheme BearerHTTPSecurityScheme
@@ -959,7 +988,7 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -972,16 +1001,16 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i BearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // APIKeyHTTPSecurityScheme structure is generated from "#/definitions/APIKeyHTTPSecurityScheme".
 type APIKeyHTTPSecurityScheme struct {
-	Type                APIKeyHTTPSecuritySchemeType `json:"type,omitempty"`
-	Name                string                       `json:"name,omitempty"`
-	In                  APIKeyHTTPSecuritySchemeIn   `json:"in,omitempty"`
-	Description         string                       `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}       `json:"-"`                     // Key must match pattern: ^x-
+	Type          APIKeyHTTPSecuritySchemeType `json:"type,omitempty"`
+	Name          string                       `json:"name,omitempty"`
+	In            APIKeyHTTPSecuritySchemeIn   `json:"in,omitempty"`
+	Description   string                       `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}       `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeyHTTPSecurityScheme APIKeyHTTPSecurityScheme
@@ -999,7 +1028,7 @@ func (i *APIKeyHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1012,7 +1041,7 @@ func (i *APIKeyHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i APIKeyHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // HTTPSecurityScheme structure is generated from "#/definitions/HTTPSecurityScheme".
@@ -1128,6 +1157,7 @@ func (i ComponentsSecuritySchemesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesAZAZ09Values map[string]ComponentsSecuritySchemesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                       map[string]interface{}                     `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
@@ -1139,6 +1169,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsSecuritySchemesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1147,7 +1178,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values)
+	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
 // Asyncapi is an enum type.
@@ -1918,11 +1949,12 @@ var (
 )
 
 type unionMap struct {
-	mustUnmarshal     []interface{}
-	mayUnmarshal      []interface{}
-	ignoreKeys        []string
-	patternProperties map[*regexp.Regexp]interface{}
-	jsonData          []byte
+	mustUnmarshal        []interface{}
+	mayUnmarshal         []interface{}
+	ignoreKeys           []string
+	patternProperties    map[*regexp.Regexp]interface{}
+	additionalProperties interface{}
+	jsonData             []byte
 }
 
 func (u unionMap) unmarshal() error {
@@ -1940,10 +1972,10 @@ func (u unionMap) unmarshal() error {
 			u.mayUnmarshal[i] = nil
 		}
 	}
-	if len(u.patternProperties) == 0 {
+
+	if len(u.patternProperties) == 0 && u.additionalProperties == nil {
 		return nil
 	}
-
 	// unmarshal to a generic map
 	var m map[string]*json.RawMessage
 	err := json.Unmarshal(u.jsonData, &m)
@@ -1968,10 +2000,35 @@ func (u unionMap) unmarshal() error {
 	if len(m) == 0 {
 		return nil
 	}
-
+	if u.additionalProperties != nil {
+		return u.unmarshalAdditionalProperties(m)
+	}
 	return nil
 }
+func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) error {
+	var err error
+	subMap := make([]byte, 1, 100)
+	subMap[0] = '{'
 
+	// Iterating map and filling additional properties.
+	for key, val := range m {
+		keyEscaped := `"` + strings.Replace(key, `"`, `\"`, -1) + `":`
+		if len(subMap) != 1 {
+			subMap = append(subMap[:len(subMap)-1], ',')
+		}
+		subMap = append(subMap, []byte(keyEscaped)...)
+		subMap = append(subMap, []byte(*val)...)
+		subMap = append(subMap, '}')
+	}
+
+	if len(subMap) > 1 {
+		err = json.Unmarshal(subMap, u.additionalProperties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) error {
 	patternMapsRaw := make(map[*regexp.Regexp][]byte, len(u.patternProperties))
 	// Iterating map and filling pattern properties sub maps.

--- a/tests/resources/go/asyncapi/entities_test.go
+++ b/tests/resources/go/asyncapi/entities_test.go
@@ -12,7 +12,7 @@ import (
 func TestInfo_MarshalJSON(t *testing.T) {
 	i := Info{
 		Version: "v1",
-		MapOfAnythingValues: map[string]interface{}{
+		MapOfAnything: map[string]interface{}{
 			"x-two": "two",
 			"x-one": 1,
 		},

--- a/tests/resources/go/asyncapi2/entities.go
+++ b/tests/resources/go/asyncapi2/entities.go
@@ -15,15 +15,15 @@ import (
 //
 // AsyncAPI 2.0.0 schema.
 type AsyncAPI struct {
-	ID                  string                 `json:"id,omitempty"`                 // A unique id representing the application.
-	Info                *Info                  `json:"info,omitempty"`               // General information about the API.
-	Servers             map[string]Server      `json:"servers,omitempty"`
-	DefaultContentType  string                 `json:"defaultContentType,omitempty"`
-	Channels            map[string]ChannelItem `json:"channels,omitempty"`
-	Components          *Components            `json:"components,omitempty"`         // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
-	Tags                []Tag                  `json:"tags,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"`       // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                            // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	ID                 string                 `json:"id,omitempty"`                 // A unique id representing the application.
+	Info               *Info                  `json:"info,omitempty"`               // General information about the API.
+	Servers            map[string]Server      `json:"servers,omitempty"`
+	DefaultContentType string                 `json:"defaultContentType,omitempty"`
+	Channels           map[string]ChannelItem `json:"channels,omitempty"`
+	Components         *Components            `json:"components,omitempty"`         // An object to hold a set of reusable objects for different aspects of the AsyncAPI Specification.
+	Tags               []Tag                  `json:"tags,omitempty"`
+	ExternalDocs       *ExternalDocs          `json:"externalDocs,omitempty"`       // information about external documentation
+	MapOfAnything      map[string]interface{} `json:"-"`                            // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalAsyncAPI AsyncAPI
@@ -45,9 +45,10 @@ func (i *AsyncAPI) UnmarshalJSON(data []byte) error {
 			"components",
 			"tags",
 			"externalDocs",
+			"asyncapi",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -68,20 +69,20 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i AsyncAPI) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAsyncAPI, marshalAsyncAPI(i), i.MapOfAnythingValues)
+	return marshalUnion(constAsyncAPI, marshalAsyncAPI(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/info".
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title. CommonMark is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // A URL to the Terms of Service for the API. MUST be in the format of a URL.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalInfo Info
@@ -101,7 +102,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"license",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -114,17 +115,17 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/contact".
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalContact Contact
@@ -141,7 +142,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -154,14 +155,14 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalLicense License
@@ -177,7 +178,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -190,21 +191,21 @@ func (i *License) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // Server structure is generated from "#/definitions/server".
 //
 // An object representing a Server.
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Protocol            string                    `json:"protocol,omitempty"`        // The transfer protocol.
-	ProtocolVersion     string                    `json:"protocolVersion,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	Security            []map[string][]string     `json:"security,omitempty"`
-	Bindings            *ServerBindingsObject     `json:"bindings,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                         // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	URL             string                    `json:"url,omitempty"`
+	Description     string                    `json:"description,omitempty"`
+	Protocol        string                    `json:"protocol,omitempty"`        // The transfer protocol.
+	ProtocolVersion string                    `json:"protocolVersion,omitempty"`
+	Variables       map[string]ServerVariable `json:"variables,omitempty"`
+	Security        []map[string][]string     `json:"security,omitempty"`
+	Bindings        *ServerBindingsObject     `json:"bindings,omitempty"`
+	MapOfAnything   map[string]interface{}    `json:"-"`                         // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalServer Server
@@ -225,7 +226,7 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 			"bindings",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -238,18 +239,18 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Server) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServer(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServer(i), i.MapOfAnything)
 }
 
 // ServerVariable structure is generated from "#/definitions/serverVariable".
 //
 // An object representing a Server Variable for server URL template substitution.
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	Examples            []string               `json:"examples,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Examples      []string               `json:"examples,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalServerVariable ServerVariable
@@ -267,7 +268,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 			"examples",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -280,36 +281,75 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ServerVariable) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServerVariable(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServerVariable(i), i.MapOfAnything)
 }
 
 // ServerBindingsObject structure is generated from "#/definitions/serverBindingsObject".
 type ServerBindingsObject struct {
-	HTTP  interface{} `json:"http,omitempty"`
-	Ws    interface{} `json:"ws,omitempty"`
-	Amqp  interface{} `json:"amqp,omitempty"`
-	Amqp1 interface{} `json:"amqp1,omitempty"`
-	Mqtt  interface{} `json:"mqtt,omitempty"`
-	Mqtt5 interface{} `json:"mqtt5,omitempty"`
-	Kafka interface{} `json:"kafka,omitempty"`
-	Nats  interface{} `json:"nats,omitempty"`
-	Jms   interface{} `json:"jms,omitempty"`
-	Sns   interface{} `json:"sns,omitempty"`
-	Sqs   interface{} `json:"sqs,omitempty"`
-	Stomp interface{} `json:"stomp,omitempty"`
-	Redis interface{} `json:"redis,omitempty"`
+	HTTP                 interface{}            `json:"http,omitempty"`
+	Ws                   interface{}            `json:"ws,omitempty"`
+	Amqp                 interface{}            `json:"amqp,omitempty"`
+	Amqp1                interface{}            `json:"amqp1,omitempty"`
+	Mqtt                 interface{}            `json:"mqtt,omitempty"`
+	Mqtt5                interface{}            `json:"mqtt5,omitempty"`
+	Kafka                interface{}            `json:"kafka,omitempty"`
+	Nats                 interface{}            `json:"nats,omitempty"`
+	Jms                  interface{}            `json:"jms,omitempty"`
+	Sns                  interface{}            `json:"sns,omitempty"`
+	Sqs                  interface{}            `json:"sqs,omitempty"`
+	Stomp                interface{}            `json:"stomp,omitempty"`
+	Redis                interface{}            `json:"redis,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`               // All unmatched properties
+}
+
+type marshalServerBindingsObject ServerBindingsObject
+
+// UnmarshalJSON decodes JSON.
+func (i *ServerBindingsObject) UnmarshalJSON(data []byte) error {
+	ii := marshalServerBindingsObject(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"http",
+			"ws",
+			"amqp",
+			"amqp1",
+			"mqtt",
+			"mqtt5",
+			"kafka",
+			"nats",
+			"jms",
+			"sns",
+			"sqs",
+			"stomp",
+			"redis",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = ServerBindingsObject(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i ServerBindingsObject) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalServerBindingsObject(i), i.AdditionalProperties)
 }
 
 // ChannelItem structure is generated from "#/definitions/channelItem".
 type ChannelItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Parameters          map[string]Parameter   `json:"parameters,omitempty"`
-	Description         string                 `json:"description,omitempty"` // A description of the channel.
-	Publish             *Operation             `json:"publish,omitempty"`
-	Subscribe           *Operation             `json:"subscribe,omitempty"`
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Bindings            *ChannelBindingsObject `json:"bindings,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Ref           string                 `json:"$ref,omitempty"`
+	Parameters    map[string]Parameter   `json:"parameters,omitempty"`
+	Description   string                 `json:"description,omitempty"` // A description of the channel.
+	Publish       *Operation             `json:"publish,omitempty"`
+	Subscribe     *Operation             `json:"subscribe,omitempty"`
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Bindings      *ChannelBindingsObject `json:"bindings,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalChannelItem ChannelItem
@@ -330,7 +370,7 @@ func (i *ChannelItem) UnmarshalJSON(data []byte) error {
 			"bindings",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -343,16 +383,16 @@ func (i *ChannelItem) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ChannelItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalChannelItem(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalChannelItem(i), i.MapOfAnything)
 }
 
 // Parameter structure is generated from "#/definitions/parameter".
 type Parameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed.
-	Schema              map[string]interface{} `json:"schema,omitempty"`
-	Location            string                 `json:"location,omitempty"`    // A runtime expression that specifies the location of the parameter value
-	Ref                 string                 `json:"$ref,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use. GitHub Flavored Markdown is allowed.
+	Schema        map[string]interface{} `json:"schema,omitempty"`
+	Location      string                 `json:"location,omitempty"`    // A runtime expression that specifies the location of the parameter value
+	Ref           string                 `json:"$ref,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalParameter Parameter
@@ -370,7 +410,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 			"$ref",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -383,20 +423,20 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything)
 }
 
 // Operation structure is generated from "#/definitions/operation".
 type Operation struct {
-	Traits              []OperationTraitsItems   `json:"traits,omitempty"`
-	Summary             string                   `json:"summary,omitempty"`
-	Description         string                   `json:"description,omitempty"`
-	Tags                []Tag                    `json:"tags,omitempty"`
-	ExternalDocs        *ExternalDocs            `json:"externalDocs,omitempty"` // information about external documentation
-	ID                  string                   `json:"operationId,omitempty"`
-	Bindings            *OperationBindingsObject `json:"bindings,omitempty"`
-	Message             *Message                 `json:"message,omitempty"`
-	MapOfAnythingValues map[string]interface{}   `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Traits        []OperationTraitsItems   `json:"traits,omitempty"`
+	Summary       string                   `json:"summary,omitempty"`
+	Description   string                   `json:"description,omitempty"`
+	Tags          []Tag                    `json:"tags,omitempty"`
+	ExternalDocs  *ExternalDocs            `json:"externalDocs,omitempty"` // information about external documentation
+	ID            string                   `json:"operationId,omitempty"`
+	Bindings      *OperationBindingsObject `json:"bindings,omitempty"`
+	Message       *Message                 `json:"message,omitempty"`
+	MapOfAnything map[string]interface{}   `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalOperation Operation
@@ -418,7 +458,7 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 			"message",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -431,23 +471,50 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Operation) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperation(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperation(i), i.MapOfAnything)
 }
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	Ref string `json:"$ref,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
+}
+
+type marshalReference Reference
+
+// UnmarshalJSON decodes JSON.
+func (i *Reference) UnmarshalJSON(data []byte) error {
+	ii := marshalReference(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$ref",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Reference(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Reference) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalReference(i), i.AdditionalProperties)
 }
 
 // OperationTrait structure is generated from "#/definitions/operationTrait".
 type OperationTrait struct {
-	Summary             string                   `json:"summary,omitempty"`
-	Description         string                   `json:"description,omitempty"`
-	Tags                []Tag                    `json:"tags,omitempty"`
-	ExternalDocs        *ExternalDocs            `json:"externalDocs,omitempty"` // information about external documentation
-	OperationID         string                   `json:"operationId,omitempty"`
-	Bindings            *OperationBindingsObject `json:"bindings,omitempty"`
-	MapOfAnythingValues map[string]interface{}   `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Summary       string                   `json:"summary,omitempty"`
+	Description   string                   `json:"description,omitempty"`
+	Tags          []Tag                    `json:"tags,omitempty"`
+	ExternalDocs  *ExternalDocs            `json:"externalDocs,omitempty"` // information about external documentation
+	OperationID   string                   `json:"operationId,omitempty"`
+	Bindings      *OperationBindingsObject `json:"bindings,omitempty"`
+	MapOfAnything map[string]interface{}   `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalOperationTrait OperationTrait
@@ -467,7 +534,7 @@ func (i *OperationTrait) UnmarshalJSON(data []byte) error {
 			"bindings",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -480,15 +547,15 @@ func (i *OperationTrait) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OperationTrait) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperationTrait(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperationTrait(i), i.MapOfAnything)
 }
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalTag Tag
@@ -505,7 +572,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -518,16 +585,16 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // ExternalDocs structure is generated from "#/definitions/externalDocs".
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalExternalDocs ExternalDocs
@@ -543,7 +610,7 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -556,36 +623,75 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocs) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocs(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocs(i), i.MapOfAnything)
 }
 
 // OperationBindingsObject structure is generated from "#/definitions/operationBindingsObject".
 type OperationBindingsObject struct {
-	HTTP  interface{}                        `json:"http,omitempty"`
-	Ws    interface{}                        `json:"ws,omitempty"`
+	HTTP                 interface{}                    `json:"http,omitempty"`
+	Ws                   interface{}                    `json:"ws,omitempty"`
 	// AMQP 0-9-1 Operation Binding Object
 	// This object contains information about the operation representation in AMQP.
 	// See https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.
-	Amqp  *AmqpOperationBindingObject010JSON `json:"amqp,omitempty"`
-	Amqp1 interface{}                        `json:"amqp1,omitempty"`
-	Mqtt  interface{}                        `json:"mqtt,omitempty"`
-	Mqtt5 interface{}                        `json:"mqtt5,omitempty"`
-	Kafka interface{}                        `json:"kafka,omitempty"`
-	Nats  interface{}                        `json:"nats,omitempty"`
-	Jms   interface{}                        `json:"jms,omitempty"`
-	Sns   interface{}                        `json:"sns,omitempty"`
-	Sqs   interface{}                        `json:"sqs,omitempty"`
-	Stomp interface{}                        `json:"stomp,omitempty"`
-	Redis interface{}                        `json:"redis,omitempty"`
+	Amqp                 *AMQP091OperationBindingObject `json:"amqp,omitempty"`
+	Amqp1                interface{}                    `json:"amqp1,omitempty"`
+	Mqtt                 interface{}                    `json:"mqtt,omitempty"`
+	Mqtt5                interface{}                    `json:"mqtt5,omitempty"`
+	Kafka                interface{}                    `json:"kafka,omitempty"`
+	Nats                 interface{}                    `json:"nats,omitempty"`
+	Jms                  interface{}                    `json:"jms,omitempty"`
+	Sns                  interface{}                    `json:"sns,omitempty"`
+	Sqs                  interface{}                    `json:"sqs,omitempty"`
+	Stomp                interface{}                    `json:"stomp,omitempty"`
+	Redis                interface{}                    `json:"redis,omitempty"`
+	AdditionalProperties map[string]interface{}         `json:"-"`               // All unmatched properties
 }
 
-// AmqpOperationBindingObject010JSON structure is generated from "amqp-operation-binding-object-0.1.0.json".
+type marshalOperationBindingsObject OperationBindingsObject
+
+// UnmarshalJSON decodes JSON.
+func (i *OperationBindingsObject) UnmarshalJSON(data []byte) error {
+	ii := marshalOperationBindingsObject(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"http",
+			"ws",
+			"amqp",
+			"amqp1",
+			"mqtt",
+			"mqtt5",
+			"kafka",
+			"nats",
+			"jms",
+			"sns",
+			"sqs",
+			"stomp",
+			"redis",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = OperationBindingsObject(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i OperationBindingsObject) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalOperationBindingsObject(i), i.AdditionalProperties)
+}
+
+// AMQP091OperationBindingObject structure is generated from "amqp-operation-binding-object-0.1.0.json".
 //
 // AMQP 0-9-1 Operation Binding Object.
 //
 // This object contains information about the operation representation in AMQP.
 // See https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.
-type AmqpOperationBindingObject010JSON struct {
+type AMQP091OperationBindingObject struct {
 	Expiration     int64                                           `json:"expiration,omitempty"`     // TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero. Applies to Publish, Subscribe.
 	UserID         string                                          `json:"userId,omitempty"`         // Identifies the user who has sent the message. Applies to Publish, Subscribe.
 	Cc             []string                                        `json:"cc,omitempty"`             // The routing keys the message should be routed to at the time of publishing. Applies to Publish, Subscribe.
@@ -601,16 +707,16 @@ type AmqpOperationBindingObject010JSON struct {
 
 // OperationTraitsItems structure is generated from "#/definitions/operation->traits->items".
 type OperationTraitsItems struct {
-	Reference      *Reference      `json:"-"`
-	OperationTrait *OperationTrait `json:"-"`
-	Interface      *[]interface{}  `json:"-"`
+	Reference       *Reference      `json:"-"`
+	OperationTrait  *OperationTrait `json:"-"`
+	SliceOfAnything []interface{}   `json:"-"`
 }
 
 type marshalOperationTraitsItems OperationTraitsItems
 
 // UnmarshalJSON decodes JSON.
 func (i *OperationTraitsItems) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Reference, &i.OperationTrait, &i.Interface}
+	mayUnmarshal := []interface{}{&i.Reference, &i.OperationTrait, &i.SliceOfAnything}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -622,7 +728,7 @@ func (i *OperationTraitsItems) UnmarshalJSON(data []byte) error {
 		i.OperationTrait = nil
 	}
 	if mayUnmarshal[2] == nil {
-		i.Interface = nil
+		i.SliceOfAnything = nil
 	}
 
 	return err
@@ -630,7 +736,7 @@ func (i *OperationTraitsItems) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OperationTraitsItems) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperationTraitsItems(i), i.Reference, i.OperationTrait, i.Interface)
+	return marshalUnion(marshalOperationTraitsItems(i), i.Reference, i.OperationTrait, i.SliceOfAnything)
 }
 
 // MessageOneOf1OneOf0 structure is generated from "#/definitions/message/oneOf/1/oneOf/0".
@@ -640,22 +746,22 @@ type MessageOneOf1OneOf0 struct {
 
 // MessageOneOf1OneOf1 structure is generated from "#/definitions/message/oneOf/1/oneOf/1".
 type MessageOneOf1OneOf1 struct {
-	SchemaFormat        string                            `json:"schemaFormat,omitempty"`
-	ContentType         string                            `json:"contentType,omitempty"`
-	Headers             map[string]interface{}            `json:"headers,omitempty"`
-	Payload             interface{}                       `json:"payload,omitempty"`
-	CorrelationID       *MessageOneOf1OneOf1CorrelationID `json:"correlationId,omitempty"`
-	Tags                []Tag                             `json:"tags,omitempty"`
-	Summary             string                            `json:"summary,omitempty"`       // A brief summary of the message.
-	Name                string                            `json:"name,omitempty"`          // Name of the message.
-	Title               string                            `json:"title,omitempty"`         // A human-friendly title for the message.
-	Description         string                            `json:"description,omitempty"`   // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs                     `json:"externalDocs,omitempty"`  // information about external documentation
-	Deprecated          bool                              `json:"deprecated,omitempty"`
-	Examples            []map[string]interface{}          `json:"examples,omitempty"`
-	Bindings            *MessageBindingsObject            `json:"bindings,omitempty"`
-	Traits              []MessageOneOf1OneOf1TraitsItems  `json:"traits,omitempty"`
-	MapOfAnythingValues map[string]interface{}            `json:"-"`                       // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	SchemaFormat  string                            `json:"schemaFormat,omitempty"`
+	ContentType   string                            `json:"contentType,omitempty"`
+	Headers       map[string]interface{}            `json:"headers,omitempty"`
+	Payload       interface{}                       `json:"payload,omitempty"`
+	CorrelationID *MessageOneOf1OneOf1CorrelationID `json:"correlationId,omitempty"`
+	Tags          []Tag                             `json:"tags,omitempty"`
+	Summary       string                            `json:"summary,omitempty"`       // A brief summary of the message.
+	Name          string                            `json:"name,omitempty"`          // Name of the message.
+	Title         string                            `json:"title,omitempty"`         // A human-friendly title for the message.
+	Description   string                            `json:"description,omitempty"`   // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs                     `json:"externalDocs,omitempty"`  // information about external documentation
+	Deprecated    bool                              `json:"deprecated,omitempty"`
+	Examples      []map[string]interface{}          `json:"examples,omitempty"`
+	Bindings      *MessageBindingsObject            `json:"bindings,omitempty"`
+	Traits        []MessageOneOf1OneOf1TraitsItems  `json:"traits,omitempty"`
+	MapOfAnything map[string]interface{}            `json:"-"`                       // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalMessageOneOf1OneOf1 MessageOneOf1OneOf1
@@ -684,7 +790,7 @@ func (i *MessageOneOf1OneOf1) UnmarshalJSON(data []byte) error {
 			"traits",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -697,14 +803,14 @@ func (i *MessageOneOf1OneOf1) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i MessageOneOf1OneOf1) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessageOneOf1OneOf1(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMessageOneOf1OneOf1(i), i.MapOfAnything)
 }
 
 // CorrelationID structure is generated from "#/definitions/correlationId".
 type CorrelationID struct {
-	Description         string                 `json:"description,omitempty"` // A optional description of the correlation ID. GitHub Flavored Markdown is allowed.
-	Location            string                 `json:"location,omitempty"`    // A runtime expression that specifies the location of the correlation ID
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"` // A optional description of the correlation ID. GitHub Flavored Markdown is allowed.
+	Location      string                 `json:"location,omitempty"`    // A runtime expression that specifies the location of the correlation ID
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalCorrelationID CorrelationID
@@ -720,7 +826,7 @@ func (i *CorrelationID) UnmarshalJSON(data []byte) error {
 			"location",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -733,7 +839,7 @@ func (i *CorrelationID) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i CorrelationID) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalCorrelationID(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalCorrelationID(i), i.MapOfAnything)
 }
 
 // MessageOneOf1OneOf1CorrelationID structure is generated from "#/definitions/message/oneOf/1/oneOf/1->correlationId".
@@ -768,31 +874,70 @@ func (i MessageOneOf1OneOf1CorrelationID) MarshalJSON() ([]byte, error) {
 
 // MessageBindingsObject structure is generated from "#/definitions/messageBindingsObject".
 type MessageBindingsObject struct {
-	HTTP  interface{}                      `json:"http,omitempty"`
-	Ws    interface{}                      `json:"ws,omitempty"`
-	// AMQP 0-9-1 Operation Binding Object
-	// This object contains information about the operation representation in AMQP.
-	// See https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.
-	Amqp  *AmqpMessageBindingObject010JSON `json:"amqp,omitempty"`
-	Amqp1 interface{}                      `json:"amqp1,omitempty"`
-	Mqtt  interface{}                      `json:"mqtt,omitempty"`
-	Mqtt5 interface{}                      `json:"mqtt5,omitempty"`
-	Kafka interface{}                      `json:"kafka,omitempty"`
-	Nats  interface{}                      `json:"nats,omitempty"`
-	Jms   interface{}                      `json:"jms,omitempty"`
-	Sns   interface{}                      `json:"sns,omitempty"`
-	Sqs   interface{}                      `json:"sqs,omitempty"`
-	Stomp interface{}                      `json:"stomp,omitempty"`
-	Redis interface{}                      `json:"redis,omitempty"`
+	HTTP                 interface{}                  `json:"http,omitempty"`
+	Ws                   interface{}                  `json:"ws,omitempty"`
+	// AMQP 0-9-1 Message Binding Object
+	// This object contains information about the message representation in AMQP.
+	// See https://github.com/asyncapi/bindings/tree/master/amqp#message-binding-object.
+	Amqp                 *AMQP091MessageBindingObject `json:"amqp,omitempty"`
+	Amqp1                interface{}                  `json:"amqp1,omitempty"`
+	Mqtt                 interface{}                  `json:"mqtt,omitempty"`
+	Mqtt5                interface{}                  `json:"mqtt5,omitempty"`
+	Kafka                interface{}                  `json:"kafka,omitempty"`
+	Nats                 interface{}                  `json:"nats,omitempty"`
+	Jms                  interface{}                  `json:"jms,omitempty"`
+	Sns                  interface{}                  `json:"sns,omitempty"`
+	Sqs                  interface{}                  `json:"sqs,omitempty"`
+	Stomp                interface{}                  `json:"stomp,omitempty"`
+	Redis                interface{}                  `json:"redis,omitempty"`
+	AdditionalProperties map[string]interface{}       `json:"-"`               // All unmatched properties
 }
 
-// AmqpMessageBindingObject010JSON structure is generated from "amqp-message-binding-object-0.1.0.json".
+type marshalMessageBindingsObject MessageBindingsObject
+
+// UnmarshalJSON decodes JSON.
+func (i *MessageBindingsObject) UnmarshalJSON(data []byte) error {
+	ii := marshalMessageBindingsObject(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"http",
+			"ws",
+			"amqp",
+			"amqp1",
+			"mqtt",
+			"mqtt5",
+			"kafka",
+			"nats",
+			"jms",
+			"sns",
+			"sqs",
+			"stomp",
+			"redis",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = MessageBindingsObject(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i MessageBindingsObject) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalMessageBindingsObject(i), i.AdditionalProperties)
+}
+
+// AMQP091MessageBindingObject structure is generated from "amqp-message-binding-object-0.1.0.json".
 //
-// AMQP 0-9-1 Operation Binding Object.
+// AMQP 0-9-1 Message Binding Object.
 //
-// This object contains information about the operation representation in AMQP.
-// See https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.
-type AmqpMessageBindingObject010JSON struct {
+// This object contains information about the message representation in AMQP.
+// See https://github.com/asyncapi/bindings/tree/master/amqp#message-binding-object.
+type AMQP091MessageBindingObject struct {
 	ContentEncoding string                                        `json:"contentEncoding,omitempty"` // A MIME encoding for the message content.
 	MessageType     string                                        `json:"messageType,omitempty"`     // Application-specific message type.
 	BindingVersion  AmqpMessageBindingObject010JSONBindingVersion `json:"bindingVersion,omitempty"`  // The version of this binding. If omitted, "latest" MUST be assumed.
@@ -800,20 +945,20 @@ type AmqpMessageBindingObject010JSON struct {
 
 // MessageTrait structure is generated from "#/definitions/messageTrait".
 type MessageTrait struct {
-	SchemaFormat        string                     `json:"schemaFormat,omitempty"`
-	ContentType         string                     `json:"contentType,omitempty"`
-	Headers             *MessageTraitHeaders       `json:"headers,omitempty"`
-	CorrelationID       *MessageTraitCorrelationID `json:"correlationId,omitempty"`
-	Tags                []Tag                      `json:"tags,omitempty"`
-	Summary             string                     `json:"summary,omitempty"`       // A brief summary of the message.
-	Name                string                     `json:"name,omitempty"`          // Name of the message.
-	Title               string                     `json:"title,omitempty"`         // A human-friendly title for the message.
-	Description         string                     `json:"description,omitempty"`   // A longer description of the message. CommonMark is allowed.
-	ExternalDocs        *ExternalDocs              `json:"externalDocs,omitempty"`  // information about external documentation
-	Deprecated          bool                       `json:"deprecated,omitempty"`
-	Examples            []map[string]interface{}   `json:"examples,omitempty"`
-	Bindings            *MessageBindingsObject     `json:"bindings,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                       // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	SchemaFormat  string                     `json:"schemaFormat,omitempty"`
+	ContentType   string                     `json:"contentType,omitempty"`
+	Headers       *MessageTraitHeaders       `json:"headers,omitempty"`
+	CorrelationID *MessageTraitCorrelationID `json:"correlationId,omitempty"`
+	Tags          []Tag                      `json:"tags,omitempty"`
+	Summary       string                     `json:"summary,omitempty"`       // A brief summary of the message.
+	Name          string                     `json:"name,omitempty"`          // Name of the message.
+	Title         string                     `json:"title,omitempty"`         // A human-friendly title for the message.
+	Description   string                     `json:"description,omitempty"`   // A longer description of the message. CommonMark is allowed.
+	ExternalDocs  *ExternalDocs              `json:"externalDocs,omitempty"`  // information about external documentation
+	Deprecated    bool                       `json:"deprecated,omitempty"`
+	Examples      []map[string]interface{}   `json:"examples,omitempty"`
+	Bindings      *MessageBindingsObject     `json:"bindings,omitempty"`
+	MapOfAnything map[string]interface{}     `json:"-"`                       // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalMessageTrait MessageTrait
@@ -840,7 +985,7 @@ func (i *MessageTrait) UnmarshalJSON(data []byte) error {
 			"bindings",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -853,7 +998,7 @@ func (i *MessageTrait) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i MessageTrait) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessageTrait(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMessageTrait(i), i.MapOfAnything)
 }
 
 // MessageTraitHeaders structure is generated from "#/definitions/messageTrait->headers".
@@ -918,16 +1063,16 @@ func (i MessageTraitCorrelationID) MarshalJSON() ([]byte, error) {
 
 // MessageOneOf1OneOf1TraitsItems structure is generated from "#/definitions/message/oneOf/1/oneOf/1->traits->items".
 type MessageOneOf1OneOf1TraitsItems struct {
-	Reference    *Reference     `json:"-"`
-	MessageTrait *MessageTrait  `json:"-"`
-	Interface    *[]interface{} `json:"-"`
+	Reference       *Reference    `json:"-"`
+	MessageTrait    *MessageTrait `json:"-"`
+	SliceOfAnything []interface{} `json:"-"`
 }
 
 type marshalMessageOneOf1OneOf1TraitsItems MessageOneOf1OneOf1TraitsItems
 
 // UnmarshalJSON decodes JSON.
 func (i *MessageOneOf1OneOf1TraitsItems) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Reference, &i.MessageTrait, &i.Interface}
+	mayUnmarshal := []interface{}{&i.Reference, &i.MessageTrait, &i.SliceOfAnything}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -939,7 +1084,7 @@ func (i *MessageOneOf1OneOf1TraitsItems) UnmarshalJSON(data []byte) error {
 		i.MessageTrait = nil
 	}
 	if mayUnmarshal[2] == nil {
-		i.Interface = nil
+		i.SliceOfAnything = nil
 	}
 
 	return err
@@ -947,7 +1092,7 @@ func (i *MessageOneOf1OneOf1TraitsItems) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i MessageOneOf1OneOf1TraitsItems) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessageOneOf1OneOf1TraitsItems(i), i.Reference, i.MessageTrait, i.Interface)
+	return marshalUnion(marshalMessageOneOf1OneOf1TraitsItems(i), i.Reference, i.MessageTrait, i.SliceOfAnything)
 }
 
 // MessageOneOf1 structure is generated from "#/definitions/message/oneOf/1".
@@ -1012,31 +1157,70 @@ func (i Message) MarshalJSON() ([]byte, error) {
 
 // ChannelBindingsObject structure is generated from "#/definitions/channelBindingsObject".
 type ChannelBindingsObject struct {
-	HTTP  interface{}                      `json:"http,omitempty"`
-	Ws    interface{}                      `json:"ws,omitempty"`
+	HTTP                 interface{}                  `json:"http,omitempty"`
+	Ws                   interface{}                  `json:"ws,omitempty"`
 	// AMQP 0-9-1 Channel Binding Object
 	// This object contains information about the channel representation in AMQP.
 	// See https://github.com/asyncapi/bindings/tree/master/amqp#channel-binding-object.
-	Amqp  *AmqpChannelBindingObject010JSON `json:"amqp,omitempty"`
-	Amqp1 interface{}                      `json:"amqp1,omitempty"`
-	Mqtt  interface{}                      `json:"mqtt,omitempty"`
-	Mqtt5 interface{}                      `json:"mqtt5,omitempty"`
-	Kafka interface{}                      `json:"kafka,omitempty"`
-	Nats  interface{}                      `json:"nats,omitempty"`
-	Jms   interface{}                      `json:"jms,omitempty"`
-	Sns   interface{}                      `json:"sns,omitempty"`
-	Sqs   interface{}                      `json:"sqs,omitempty"`
-	Stomp interface{}                      `json:"stomp,omitempty"`
-	Redis interface{}                      `json:"redis,omitempty"`
+	Amqp                 *AMQP091ChannelBindingObject `json:"amqp,omitempty"`
+	Amqp1                interface{}                  `json:"amqp1,omitempty"`
+	Mqtt                 interface{}                  `json:"mqtt,omitempty"`
+	Mqtt5                interface{}                  `json:"mqtt5,omitempty"`
+	Kafka                interface{}                  `json:"kafka,omitempty"`
+	Nats                 interface{}                  `json:"nats,omitempty"`
+	Jms                  interface{}                  `json:"jms,omitempty"`
+	Sns                  interface{}                  `json:"sns,omitempty"`
+	Sqs                  interface{}                  `json:"sqs,omitempty"`
+	Stomp                interface{}                  `json:"stomp,omitempty"`
+	Redis                interface{}                  `json:"redis,omitempty"`
+	AdditionalProperties map[string]interface{}       `json:"-"`               // All unmatched properties
 }
 
-// AmqpChannelBindingObject010JSON structure is generated from "amqp-channel-binding-object-0.1.0.json".
+type marshalChannelBindingsObject ChannelBindingsObject
+
+// UnmarshalJSON decodes JSON.
+func (i *ChannelBindingsObject) UnmarshalJSON(data []byte) error {
+	ii := marshalChannelBindingsObject(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"http",
+			"ws",
+			"amqp",
+			"amqp1",
+			"mqtt",
+			"mqtt5",
+			"kafka",
+			"nats",
+			"jms",
+			"sns",
+			"sqs",
+			"stomp",
+			"redis",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = ChannelBindingsObject(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i ChannelBindingsObject) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalChannelBindingsObject(i), i.AdditionalProperties)
+}
+
+// AMQP091ChannelBindingObject structure is generated from "amqp-channel-binding-object-0.1.0.json".
 //
 // AMQP 0-9-1 Channel Binding Object.
 //
 // This object contains information about the channel representation in AMQP.
 // See https://github.com/asyncapi/bindings/tree/master/amqp#channel-binding-object.
-type AmqpChannelBindingObject010JSON struct {
+type AMQP091ChannelBindingObject struct {
 	Is             AmqpChannelBindingObject010JSONIs             `json:"is,omitempty"`             // Defines what type of channel is it. Can be either `queue` or `routingKey` (default).
 	Exchange       *Exchange                                     `json:"exchange,omitempty"`       // When `is`=`routingKey`, this object defines the exchange properties.
 	Queue          *Queue                                        `json:"queue,omitempty"`          // When `is`=`queue`, this object defines the queue properties.
@@ -1047,20 +1231,80 @@ type AmqpChannelBindingObject010JSON struct {
 //
 // When `is`=`routingKey`, this object defines the exchange properties.
 type Exchange struct {
-	Name       string       `json:"name,omitempty"`       // The name of the exchange. It MUST NOT exceed 255 characters long.
-	Type       ExchangeType `json:"type,omitempty"`       // The type of the exchange. Can be either `topic`, `direct`, `fanout`, `default` or `headers`.
-	Durable    bool         `json:"durable,omitempty"`    // Whether the exchange should survive broker restarts or not.
-	AutoDelete bool         `json:"autoDelete,omitempty"` // Whether the exchange should be deleted when the last queue is unbound from it.
+	Name                 string                 `json:"name,omitempty"`       // The name of the exchange. It MUST NOT exceed 255 characters long.
+	Type                 ExchangeType           `json:"type,omitempty"`       // The type of the exchange. Can be either `topic`, `direct`, `fanout`, `default` or `headers`.
+	Durable              bool                   `json:"durable,omitempty"`    // Whether the exchange should survive broker restarts or not.
+	AutoDelete           bool                   `json:"autoDelete,omitempty"` // Whether the exchange should be deleted when the last queue is unbound from it.
+	AdditionalProperties map[string]interface{} `json:"-"`                    // All unmatched properties
+}
+
+type marshalExchange Exchange
+
+// UnmarshalJSON decodes JSON.
+func (i *Exchange) UnmarshalJSON(data []byte) error {
+	ii := marshalExchange(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"name",
+			"type",
+			"durable",
+			"autoDelete",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Exchange(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Exchange) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalExchange(i), i.AdditionalProperties)
 }
 
 // Queue structure is generated from "#/definitions/queue".
 //
 // When `is`=`queue`, this object defines the queue properties.
 type Queue struct {
-	Name       string `json:"name,omitempty"`       // The name of the queue. It MUST NOT exceed 255 characters long.
-	Durable    bool   `json:"durable,omitempty"`    // Whether the queue should survive broker restarts or not.
-	Exclusive  bool   `json:"exclusive,omitempty"`  // Whether the queue should be used only by one connection or not.
-	AutoDelete bool   `json:"autoDelete,omitempty"` // Whether the queue should be deleted when the last consumer unsubscribes.
+	Name                 string                 `json:"name,omitempty"`       // The name of the queue. It MUST NOT exceed 255 characters long.
+	Durable              bool                   `json:"durable,omitempty"`    // Whether the queue should survive broker restarts or not.
+	Exclusive            bool                   `json:"exclusive,omitempty"`  // Whether the queue should be used only by one connection or not.
+	AutoDelete           bool                   `json:"autoDelete,omitempty"` // Whether the queue should be deleted when the last consumer unsubscribes.
+	AdditionalProperties map[string]interface{} `json:"-"`                    // All unmatched properties
+}
+
+type marshalQueue Queue
+
+// UnmarshalJSON decodes JSON.
+func (i *Queue) UnmarshalJSON(data []byte) error {
+	ii := marshalQueue(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"name",
+			"durable",
+			"exclusive",
+			"autoDelete",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Queue(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Queue) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalQueue(i), i.AdditionalProperties)
 }
 
 // Components structure is generated from "#/definitions/components".
@@ -1082,8 +1326,8 @@ type Components struct {
 
 // UserPassword structure is generated from "#/definitions/userPassword".
 type UserPassword struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalUserPassword UserPassword
@@ -1098,9 +1342,10 @@ func (i *UserPassword) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1121,14 +1366,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i UserPassword) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnythingValues)
+	return marshalUnion(constUserPassword, marshalUserPassword(i), i.MapOfAnything)
 }
 
 // APIKey structure is generated from "#/definitions/apiKey".
 type APIKey struct {
-	In                  APIKeyIn               `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	In            APIKeyIn               `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalAPIKey APIKey
@@ -1144,9 +1389,10 @@ func (i *APIKey) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1167,13 +1413,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKey) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKey, marshalAPIKey(i), i.MapOfAnything)
 }
 
 // X509 structure is generated from "#/definitions/X509".
 type X509 struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalX509 X509
@@ -1188,9 +1434,10 @@ func (i *X509) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1211,13 +1458,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i X509) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constX509, marshalX509(i), i.MapOfAnythingValues)
+	return marshalUnion(constX509, marshalX509(i), i.MapOfAnything)
 }
 
 // SymmetricEncryption structure is generated from "#/definitions/symmetricEncryption".
 type SymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalSymmetricEncryption SymmetricEncryption
@@ -1232,9 +1479,10 @@ func (i *SymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1255,13 +1503,13 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i SymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constSymmetricEncryption, marshalSymmetricEncryption(i), i.MapOfAnything)
 }
 
 // AsymmetricEncryption structure is generated from "#/definitions/asymmetricEncryption".
 type AsymmetricEncryption struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalAsymmetricEncryption AsymmetricEncryption
@@ -1276,9 +1524,10 @@ func (i *AsymmetricEncryption) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1299,14 +1548,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i AsymmetricEncryption) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnythingValues)
+	return marshalUnion(constAsymmetricEncryption, marshalAsymmetricEncryption(i), i.MapOfAnything)
 }
 
 // NonBearerHTTPSecurityScheme structure is generated from "#/definitions/NonBearerHTTPSecurityScheme".
 type NonBearerHTTPSecurityScheme struct {
-	Scheme              string                 `json:"scheme,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Scheme        string                 `json:"scheme,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalNonBearerHTTPSecurityScheme NonBearerHTTPSecurityScheme
@@ -1322,9 +1571,10 @@ func (i *NonBearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"scheme",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1345,14 +1595,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i NonBearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constNonBearerHTTPSecurityScheme, marshalNonBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // BearerHTTPSecurityScheme structure is generated from "#/definitions/BearerHTTPSecurityScheme".
 type BearerHTTPSecurityScheme struct {
-	BearerFormat        string                 `json:"bearerFormat,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	BearerFormat  string                 `json:"bearerFormat,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalBearerHTTPSecurityScheme BearerHTTPSecurityScheme
@@ -1368,9 +1618,11 @@ func (i *BearerHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"bearerFormat",
 			"description",
+			"scheme",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1394,15 +1646,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i BearerHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constBearerHTTPSecurityScheme, marshalBearerHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // APIKeyHTTPSecurityScheme structure is generated from "#/definitions/APIKeyHTTPSecurityScheme".
 type APIKeyHTTPSecurityScheme struct {
-	Name                string                     `json:"name,omitempty"`
-	In                  APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
-	Description         string                     `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Name          string                     `json:"name,omitempty"`
+	In            APIKeyHTTPSecuritySchemeIn `json:"in,omitempty"`
+	Description   string                     `json:"description,omitempty"`
+	MapOfAnything map[string]interface{}     `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalAPIKeyHTTPSecurityScheme APIKeyHTTPSecurityScheme
@@ -1419,9 +1671,10 @@ func (i *APIKeyHTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"name",
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1442,7 +1695,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKeyHTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKeyHTTPSecurityScheme, marshalAPIKeyHTTPSecurityScheme(i), i.MapOfAnything)
 }
 
 // HTTPSecurityScheme structure is generated from "#/definitions/HTTPSecurityScheme".
@@ -1481,9 +1734,10 @@ func (i HTTPSecurityScheme) MarshalJSON() ([]byte, error) {
 
 // Oauth2Flows structure is generated from "#/definitions/oauth2Flows".
 type Oauth2Flows struct {
-	Description         string                 `json:"description,omitempty"`
-	Flows               *Oauth2FlowsFlows      `json:"flows,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description          string                 `json:"description,omitempty"`
+	Flows                *Oauth2FlowsFlows      `json:"flows,omitempty"`
+	MapOfAnything        map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	AdditionalProperties map[string]interface{} `json:"-"`                     // All unmatched properties
 }
 
 type marshalOauth2Flows Oauth2Flows
@@ -1499,10 +1753,12 @@ func (i *Oauth2Flows) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"description",
 			"flows",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
+		additionalProperties: &ii.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["type"]; !ok || string(v) != `"oauth2"` {
@@ -1522,7 +1778,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Oauth2Flows) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOauth2Flows, marshalOauth2Flows(i), i.MapOfAnythingValues)
+	return marshalUnion(constOauth2Flows, marshalOauth2Flows(i), i.MapOfAnything, i.AdditionalProperties)
 }
 
 // Oauth2FlowsFlows structure is generated from "#/definitions/oauth2Flows->flows".
@@ -1535,11 +1791,11 @@ type Oauth2FlowsFlows struct {
 
 // Oauth2Flow structure is generated from "#/definitions/oauth2Flow".
 type Oauth2Flow struct {
-	AuthorizationURL    string                 `json:"authorizationUrl,omitempty"`
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	RefreshURL          string                 `json:"refreshUrl,omitempty"`
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	AuthorizationURL string                 `json:"authorizationUrl,omitempty"`
+	TokenURL         string                 `json:"tokenUrl,omitempty"`
+	RefreshURL       string                 `json:"refreshUrl,omitempty"`
+	Scopes           map[string]string      `json:"scopes,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalOauth2Flow Oauth2Flow
@@ -1557,7 +1813,7 @@ func (i *Oauth2Flow) UnmarshalJSON(data []byte) error {
 			"scopes",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1570,14 +1826,14 @@ func (i *Oauth2Flow) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Oauth2Flow) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOauth2Flow(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOauth2Flow(i), i.MapOfAnything)
 }
 
 // OpenIDConnect structure is generated from "#/definitions/openIdConnect".
 type OpenIDConnect struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"openIdConnectUrl,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-[\w\d\.\-\_]+$
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"openIdConnectUrl,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-[\w\d\.\-\_]+$
 }
 
 type marshalOpenIDConnect OpenIDConnect
@@ -1593,9 +1849,10 @@ func (i *OpenIDConnect) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"description",
 			"openIdConnectUrl",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexXWD: &ii.MapOfAnythingValues, // ^x-[\w\d\.\-\_]+$
+			regexXWD: &ii.MapOfAnything, // ^x-[\w\d\.\-\_]+$
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1616,7 +1873,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i OpenIDConnect) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOpenIDConnect, marshalOpenIDConnect(i), i.MapOfAnythingValues)
+	return marshalUnion(constOpenIDConnect, marshalOpenIDConnect(i), i.MapOfAnything)
 }
 
 // SecurityScheme structure is generated from "#/definitions/SecurityScheme".
@@ -1706,6 +1963,7 @@ func (i ComponentsSecuritySchemesWD) MarshalJSON() ([]byte, error) {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesWDValues map[string]ComponentsSecuritySchemesWD `json:"-"` // Key must match pattern: ^[\w\d\.\-_]+$
+	AdditionalProperties                   map[string]interface{}                 `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
@@ -1717,6 +1975,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexWD: &i.MapOfComponentsSecuritySchemesWDValues, // ^[\w\d\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1725,7 +1984,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesWDValues)
+	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesWDValues, i.AdditionalProperties)
 }
 
 // ComponentsCorrelationIdsWD structure is generated from "#/definitions/components->correlationIds->^[\w\d\.\-_]+$".
@@ -1761,6 +2020,7 @@ func (i ComponentsCorrelationIdsWD) MarshalJSON() ([]byte, error) {
 // ComponentsCorrelationIds structure is generated from "#/definitions/components->correlationIds".
 type ComponentsCorrelationIds struct {
 	MapOfComponentsCorrelationIdsWDValues map[string]ComponentsCorrelationIdsWD `json:"-"` // Key must match pattern: ^[\w\d\.\-_]+$
+	AdditionalProperties                  map[string]interface{}                `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsCorrelationIds ComponentsCorrelationIds
@@ -1772,6 +2032,7 @@ func (i *ComponentsCorrelationIds) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexWD: &i.MapOfComponentsCorrelationIdsWDValues, // ^[\w\d\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1780,7 +2041,7 @@ func (i *ComponentsCorrelationIds) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsCorrelationIds) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsCorrelationIds(i), i.MapOfComponentsCorrelationIdsWDValues)
+	return marshalUnion(marshalComponentsCorrelationIds(i), i.MapOfComponentsCorrelationIdsWDValues, i.AdditionalProperties)
 }
 
 // AmqpOperationBindingObject010JSONDeliveryMode is an enum type.
@@ -2178,11 +2439,12 @@ var (
 )
 
 type unionMap struct {
-	mustUnmarshal     []interface{}
-	mayUnmarshal      []interface{}
-	ignoreKeys        []string
-	patternProperties map[*regexp.Regexp]interface{}
-	jsonData          []byte
+	mustUnmarshal        []interface{}
+	mayUnmarshal         []interface{}
+	ignoreKeys           []string
+	patternProperties    map[*regexp.Regexp]interface{}
+	additionalProperties interface{}
+	jsonData             []byte
 }
 
 func (u unionMap) unmarshal() error {
@@ -2200,10 +2462,10 @@ func (u unionMap) unmarshal() error {
 			u.mayUnmarshal[i] = nil
 		}
 	}
-	if len(u.patternProperties) == 0 {
+
+	if len(u.patternProperties) == 0 && u.additionalProperties == nil {
 		return nil
 	}
-
 	// unmarshal to a generic map
 	var m map[string]*json.RawMessage
 	err := json.Unmarshal(u.jsonData, &m)
@@ -2228,10 +2490,35 @@ func (u unionMap) unmarshal() error {
 	if len(m) == 0 {
 		return nil
 	}
-
+	if u.additionalProperties != nil {
+		return u.unmarshalAdditionalProperties(m)
+	}
 	return nil
 }
+func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) error {
+	var err error
+	subMap := make([]byte, 1, 100)
+	subMap[0] = '{'
 
+	// Iterating map and filling additional properties.
+	for key, val := range m {
+		keyEscaped := `"` + strings.Replace(key, `"`, `\"`, -1) + `":`
+		if len(subMap) != 1 {
+			subMap = append(subMap[:len(subMap)-1], ',')
+		}
+		subMap = append(subMap, []byte(keyEscaped)...)
+		subMap = append(subMap, []byte(*val)...)
+		subMap = append(subMap, '}')
+	}
+
+	if len(subMap) > 1 {
+		err = json.Unmarshal(subMap, u.additionalProperties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) error {
 	patternMapsRaw := make(map[*regexp.Regexp][]byte, len(u.patternProperties))
 	// Iterating map and filling pattern properties sub maps.

--- a/tests/resources/go/asyncapi2/entities_test.go
+++ b/tests/resources/go/asyncapi2/entities_test.go
@@ -13,7 +13,7 @@ import (
 func TestInfo_MarshalJSON(t *testing.T) {
 	i := Info{
 		Version: "v1",
-		MapOfAnythingValues: map[string]interface{}{
+		MapOfAnything: map[string]interface{}{
 			"x-two": "two",
 			"x-one": 1,
 		},

--- a/tests/resources/go/draft7/entities.go
+++ b/tests/resources/go/draft7/entities.go
@@ -7,36 +7,38 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 )
 
-// Schema structure is generated from "#".
+// CoreSchemaMetaSchema structure is generated from "#[object]".
 //
 // Core schema meta-schema.
-type Schema struct {
-	ID                   string                                      `json:"$id,omitempty"`
-	Schema               *Schema                                     `json:"-"`
-	Ref                  string                                      `json:"$ref,omitempty"`
-	Comment              string                                      `json:"$comment,omitempty"`
-	Title                string                                      `json:"title,omitempty"`
-	Description          string                                      `json:"description,omitempty"`
+type CoreSchemaMetaSchema struct {
+	ID                   *string                                     `json:"$id,omitempty"`
+	Schema               *string                                     `json:"$schema,omitempty"`
+	Ref                  *string                                     `json:"$ref,omitempty"`
+	Comment              *string                                     `json:"$comment,omitempty"`
+	Title                *string                                     `json:"title,omitempty"`
+	Description          *string                                     `json:"description,omitempty"`
 	Default              interface{}                                 `json:"default,omitempty"`
-	ReadOnly             bool                                        `json:"readOnly,omitempty"`
+	ReadOnly             *bool                                       `json:"readOnly,omitempty"`
 	Examples             []interface{}                               `json:"examples,omitempty"`
-	MultipleOf           float64                                     `json:"multipleOf,omitempty"`
-	Maximum              float64                                     `json:"maximum,omitempty"`
-	ExclusiveMaximum     float64                                     `json:"exclusiveMaximum,omitempty"`
-	Minimum              float64                                     `json:"minimum,omitempty"`
-	ExclusiveMinimum     float64                                     `json:"exclusiveMinimum,omitempty"`
-	MaxLength            int64                                       `json:"maxLength,omitempty"`
+	MultipleOf           *float64                                    `json:"multipleOf,omitempty"`
+	Maximum              *float64                                    `json:"maximum,omitempty"`
+	ExclusiveMaximum     *float64                                    `json:"exclusiveMaximum,omitempty"`
+	Minimum              *float64                                    `json:"minimum,omitempty"`
+	ExclusiveMinimum     *float64                                    `json:"exclusiveMinimum,omitempty"`
+	MaxLength            *int64                                      `json:"maxLength,omitempty"`
 	MinLength            int64                                       `json:"minLength,omitempty"`
-	Pattern              string                                      `json:"pattern,omitempty"`
+	Pattern              *string                                     `json:"pattern,omitempty"`
+	ExtraProperties      map[string]interface{}                      `json:"-"`                              // All unmatched properties
 	AdditionalItems      *Schema                                     `json:"additionalItems,omitempty"`      // Core schema meta-schema
 	Items                *Items                                      `json:"items,omitempty"`
-	MaxItems             int64                                       `json:"maxItems,omitempty"`
+	MaxItems             *int64                                      `json:"maxItems,omitempty"`
 	MinItems             int64                                       `json:"minItems,omitempty"`
-	UniqueItems          bool                                        `json:"uniqueItems,omitempty"`
+	UniqueItems          *bool                                       `json:"uniqueItems,omitempty"`
 	Contains             *Schema                                     `json:"contains,omitempty"`             // Core schema meta-schema
-	MaxProperties        int64                                       `json:"maxProperties,omitempty"`
+	MaxProperties        *int64                                      `json:"maxProperties,omitempty"`
 	MinProperties        int64                                       `json:"minProperties,omitempty"`
 	Required             []string                                    `json:"required,omitempty"`
 	AdditionalProperties *Schema                                     `json:"additionalProperties,omitempty"` // Core schema meta-schema
@@ -48,9 +50,9 @@ type Schema struct {
 	Const                interface{}                                 `json:"const,omitempty"`
 	Enum                 []interface{}                               `json:"enum,omitempty"`
 	Type                 *Type                                       `json:"type,omitempty"`
-	Format               string                                      `json:"format,omitempty"`
-	ContentMediaType     string                                      `json:"contentMediaType,omitempty"`
-	ContentEncoding      string                                      `json:"contentEncoding,omitempty"`
+	Format               *string                                     `json:"format,omitempty"`
+	ContentMediaType     *string                                     `json:"contentMediaType,omitempty"`
+	ContentEncoding      *string                                     `json:"contentEncoding,omitempty"`
 	If                   *Schema                                     `json:"if,omitempty"`                   // Core schema meta-schema
 	Then                 *Schema                                     `json:"then,omitempty"`                 // Core schema meta-schema
 	Else                 *Schema                                     `json:"else,omitempty"`                 // Core schema meta-schema
@@ -58,53 +60,121 @@ type Schema struct {
 	AnyOf                []Schema                                    `json:"anyOf,omitempty"`
 	OneOf                []Schema                                    `json:"oneOf,omitempty"`
 	Not                  *Schema                                     `json:"not,omitempty"`                  // Core schema meta-schema
-	Type0                *Type0                                      `json:"-"`
-	Type1                *Type1                                      `json:"-"`
+}
+
+type marshalCoreSchemaMetaSchema CoreSchemaMetaSchema
+
+// UnmarshalJSON decodes JSON.
+func (i *CoreSchemaMetaSchema) UnmarshalJSON(data []byte) error {
+	ii := marshalCoreSchemaMetaSchema(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$id",
+			"$schema",
+			"$ref",
+			"$comment",
+			"title",
+			"description",
+			"default",
+			"readOnly",
+			"examples",
+			"multipleOf",
+			"maximum",
+			"exclusiveMaximum",
+			"minimum",
+			"exclusiveMinimum",
+			"maxLength",
+			"minLength",
+			"pattern",
+			"additionalItems",
+			"items",
+			"maxItems",
+			"minItems",
+			"uniqueItems",
+			"contains",
+			"maxProperties",
+			"minProperties",
+			"required",
+			"additionalProperties",
+			"definitions",
+			"properties",
+			"patternProperties",
+			"dependencies",
+			"propertyNames",
+			"const",
+			"enum",
+			"type",
+			"format",
+			"contentMediaType",
+			"contentEncoding",
+			"if",
+			"then",
+			"else",
+			"allOf",
+			"anyOf",
+			"oneOf",
+			"not",
+		},
+		additionalProperties: &ii.ExtraProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = CoreSchemaMetaSchema(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i CoreSchemaMetaSchema) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalCoreSchemaMetaSchema(i), i.ExtraProperties)
+}
+
+// Schema structure is generated from "#".
+//
+// Core schema meta-schema.
+type Schema struct {
+	TypeObject  *CoreSchemaMetaSchema `json:"-"`
+	TypeBoolean *bool                 `json:"-"`
 }
 
 type marshalSchema Schema
 
 // UnmarshalJSON decodes JSON.
 func (i *Schema) UnmarshalJSON(data []byte) error {
-	ii := marshalSchema(*i)
-	mayUnmarshal := []interface{}{&ii.Schema, &ii.Type0, &ii.Type1}
+	mayUnmarshal := []interface{}{&i.TypeObject, &i.TypeBoolean}
 	err := unionMap{
-		mustUnmarshal: []interface{}{&ii},
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
 	}.unmarshal()
 	if mayUnmarshal[0] == nil {
-		ii.Schema = nil
+		i.TypeObject = nil
 	}
 	if mayUnmarshal[1] == nil {
-		ii.Type0 = nil
+		i.TypeBoolean = nil
 	}
-	if mayUnmarshal[2] == nil {
-		ii.Type1 = nil
-	}
-	if err != nil {
-		return err
-	}
-	*i = Schema(ii)
+
 	return err
 }
 
 // MarshalJSON encodes JSON.
 func (i Schema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalSchema(i), i.Schema, i.Type0, i.Type1)
+	return marshalUnion(marshalSchema(i), i.TypeObject, i.TypeBoolean)
 }
 
-// Items structure is generated from "#->items".
+// Items structure is generated from "#[object]->items".
 type Items struct {
-	Schema *Schema  `json:"-"`
-	AnyOf1 []Schema `json:"-"`
+	Schema              *Schema  `json:"-"`
+	SliceOfSchemaValues []Schema `json:"-"`
 }
 
 type marshalItems Items
 
 // UnmarshalJSON decodes JSON.
 func (i *Items) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Schema, &i.AnyOf1}
+	mayUnmarshal := []interface{}{&i.Schema, &i.SliceOfSchemaValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -113,7 +183,7 @@ func (i *Items) UnmarshalJSON(data []byte) error {
 		i.Schema = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.AnyOf1 = nil
+		i.SliceOfSchemaValues = nil
 	}
 
 	return err
@@ -121,20 +191,20 @@ func (i *Items) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Items) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalItems(i), i.Schema, i.AnyOf1)
+	return marshalUnion(marshalItems(i), i.Schema, i.SliceOfSchemaValues)
 }
 
-// DependenciesAdditionalProperties structure is generated from "#->dependencies->additionalProperties".
+// DependenciesAdditionalProperties structure is generated from "#[object]->dependencies->additionalProperties".
 type DependenciesAdditionalProperties struct {
-	Schema *Schema  `json:"-"`
-	AnyOf1 []string `json:"-"`
+	Schema              *Schema  `json:"-"`
+	SliceOfStringValues []string `json:"-"`
 }
 
 type marshalDependenciesAdditionalProperties DependenciesAdditionalProperties
 
 // UnmarshalJSON decodes JSON.
 func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Schema, &i.AnyOf1}
+	mayUnmarshal := []interface{}{&i.Schema, &i.SliceOfStringValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -143,7 +213,7 @@ func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
 		i.Schema = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.AnyOf1 = nil
+		i.SliceOfStringValues = nil
 	}
 
 	return err
@@ -151,20 +221,20 @@ func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i DependenciesAdditionalProperties) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalDependenciesAdditionalProperties(i), i.Schema, i.AnyOf1)
+	return marshalUnion(marshalDependenciesAdditionalProperties(i), i.Schema, i.SliceOfStringValues)
 }
 
-// Type structure is generated from "#->type".
+// Type structure is generated from "#[object]->type".
 type Type struct {
-	SimpleTypes *SimpleTypes  `json:"-"`
-	AnyOf1      []SimpleTypes `json:"-"`
+	SimpleTypes              *SimpleTypes  `json:"-"`
+	SliceOfSimpleTypesValues []SimpleTypes `json:"-"`
 }
 
 type marshalType Type
 
 // UnmarshalJSON decodes JSON.
 func (i *Type) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.SimpleTypes, &i.AnyOf1}
+	mayUnmarshal := []interface{}{&i.SimpleTypes, &i.SliceOfSimpleTypesValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -173,7 +243,7 @@ func (i *Type) UnmarshalJSON(data []byte) error {
 		i.SimpleTypes = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.AnyOf1 = nil
+		i.SliceOfSimpleTypesValues = nil
 	}
 
 	return err
@@ -181,109 +251,7 @@ func (i *Type) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Type) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalType(i), i.SimpleTypes, i.AnyOf1)
-}
-
-// Type0 structure is generated from "#/type/0".
-//
-// Core schema meta-schema.
-type Type0 struct {
-	ID                   string                                      `json:"$id,omitempty"`
-	Schema               string                                      `json:"$schema,omitempty"`
-	Ref                  string                                      `json:"$ref,omitempty"`
-	Comment              string                                      `json:"$comment,omitempty"`
-	Title                string                                      `json:"title,omitempty"`
-	Description          string                                      `json:"description,omitempty"`
-	Default              interface{}                                 `json:"default,omitempty"`
-	ReadOnly             bool                                        `json:"readOnly,omitempty"`
-	Examples             []interface{}                               `json:"examples,omitempty"`
-	MultipleOf           float64                                     `json:"multipleOf,omitempty"`
-	Maximum              float64                                     `json:"maximum,omitempty"`
-	ExclusiveMaximum     float64                                     `json:"exclusiveMaximum,omitempty"`
-	Minimum              float64                                     `json:"minimum,omitempty"`
-	ExclusiveMinimum     float64                                     `json:"exclusiveMinimum,omitempty"`
-	MaxLength            int64                                       `json:"maxLength,omitempty"`
-	MinLength            int64                                       `json:"minLength,omitempty"`
-	Pattern              string                                      `json:"pattern,omitempty"`
-	AdditionalItems      *Schema                                     `json:"additionalItems,omitempty"`      // Core schema meta-schema
-	Items                *Items                                      `json:"items,omitempty"`
-	MaxItems             int64                                       `json:"maxItems,omitempty"`
-	MinItems             int64                                       `json:"minItems,omitempty"`
-	UniqueItems          bool                                        `json:"uniqueItems,omitempty"`
-	Contains             *Schema                                     `json:"contains,omitempty"`             // Core schema meta-schema
-	MaxProperties        int64                                       `json:"maxProperties,omitempty"`
-	MinProperties        int64                                       `json:"minProperties,omitempty"`
-	Required             []string                                    `json:"required,omitempty"`
-	AdditionalProperties *Schema                                     `json:"additionalProperties,omitempty"` // Core schema meta-schema
-	Definitions          map[string]Schema                           `json:"definitions,omitempty"`
-	Properties           map[string]Schema                           `json:"properties,omitempty"`
-	PatternProperties    map[string]Schema                           `json:"patternProperties,omitempty"`
-	Dependencies         map[string]DependenciesAdditionalProperties `json:"dependencies,omitempty"`
-	PropertyNames        *Schema                                     `json:"propertyNames,omitempty"`        // Core schema meta-schema
-	Const                interface{}                                 `json:"const,omitempty"`
-	Enum                 []interface{}                               `json:"enum,omitempty"`
-	Type                 *Type                                       `json:"type,omitempty"`
-	Format               string                                      `json:"format,omitempty"`
-	ContentMediaType     string                                      `json:"contentMediaType,omitempty"`
-	ContentEncoding      string                                      `json:"contentEncoding,omitempty"`
-	If                   *Schema                                     `json:"if,omitempty"`                   // Core schema meta-schema
-	Then                 *Schema                                     `json:"then,omitempty"`                 // Core schema meta-schema
-	Else                 *Schema                                     `json:"else,omitempty"`                 // Core schema meta-schema
-	AllOf                []Schema                                    `json:"allOf,omitempty"`
-	AnyOf                []Schema                                    `json:"anyOf,omitempty"`
-	OneOf                []Schema                                    `json:"oneOf,omitempty"`
-	Not                  *Schema                                     `json:"not,omitempty"`                  // Core schema meta-schema
-}
-
-// Type1 structure is generated from "#/type/1".
-//
-// Core schema meta-schema.
-type Type1 struct {
-	ID                   string                                      `json:"$id,omitempty"`
-	Schema               string                                      `json:"$schema,omitempty"`
-	Ref                  string                                      `json:"$ref,omitempty"`
-	Comment              string                                      `json:"$comment,omitempty"`
-	Title                string                                      `json:"title,omitempty"`
-	Description          string                                      `json:"description,omitempty"`
-	Default              interface{}                                 `json:"default,omitempty"`
-	ReadOnly             bool                                        `json:"readOnly,omitempty"`
-	Examples             []interface{}                               `json:"examples,omitempty"`
-	MultipleOf           float64                                     `json:"multipleOf,omitempty"`
-	Maximum              float64                                     `json:"maximum,omitempty"`
-	ExclusiveMaximum     float64                                     `json:"exclusiveMaximum,omitempty"`
-	Minimum              float64                                     `json:"minimum,omitempty"`
-	ExclusiveMinimum     float64                                     `json:"exclusiveMinimum,omitempty"`
-	MaxLength            int64                                       `json:"maxLength,omitempty"`
-	MinLength            int64                                       `json:"minLength,omitempty"`
-	Pattern              string                                      `json:"pattern,omitempty"`
-	AdditionalItems      *Schema                                     `json:"additionalItems,omitempty"`      // Core schema meta-schema
-	Items                *Items                                      `json:"items,omitempty"`
-	MaxItems             int64                                       `json:"maxItems,omitempty"`
-	MinItems             int64                                       `json:"minItems,omitempty"`
-	UniqueItems          bool                                        `json:"uniqueItems,omitempty"`
-	Contains             *Schema                                     `json:"contains,omitempty"`             // Core schema meta-schema
-	MaxProperties        int64                                       `json:"maxProperties,omitempty"`
-	MinProperties        int64                                       `json:"minProperties,omitempty"`
-	Required             []string                                    `json:"required,omitempty"`
-	AdditionalProperties *Schema                                     `json:"additionalProperties,omitempty"` // Core schema meta-schema
-	Definitions          map[string]Schema                           `json:"definitions,omitempty"`
-	Properties           map[string]Schema                           `json:"properties,omitempty"`
-	PatternProperties    map[string]Schema                           `json:"patternProperties,omitempty"`
-	Dependencies         map[string]DependenciesAdditionalProperties `json:"dependencies,omitempty"`
-	PropertyNames        *Schema                                     `json:"propertyNames,omitempty"`        // Core schema meta-schema
-	Const                interface{}                                 `json:"const,omitempty"`
-	Enum                 []interface{}                               `json:"enum,omitempty"`
-	Type                 *Type                                       `json:"type,omitempty"`
-	Format               string                                      `json:"format,omitempty"`
-	ContentMediaType     string                                      `json:"contentMediaType,omitempty"`
-	ContentEncoding      string                                      `json:"contentEncoding,omitempty"`
-	If                   *Schema                                     `json:"if,omitempty"`                   // Core schema meta-schema
-	Then                 *Schema                                     `json:"then,omitempty"`                 // Core schema meta-schema
-	Else                 *Schema                                     `json:"else,omitempty"`                 // Core schema meta-schema
-	AllOf                []Schema                                    `json:"allOf,omitempty"`
-	AnyOf                []Schema                                    `json:"anyOf,omitempty"`
-	OneOf                []Schema                                    `json:"oneOf,omitempty"`
-	Not                  *Schema                                     `json:"not,omitempty"`                  // Core schema meta-schema
+	return marshalUnion(marshalType(i), i.SimpleTypes, i.SliceOfSimpleTypesValues)
 }
 
 // SimpleTypes is an enum type.
@@ -384,9 +352,11 @@ func marshalUnion(maps ...interface{}) ([]byte, error) {
 	return result, nil
 }
 type unionMap struct {
-	mustUnmarshal []interface{}
-	mayUnmarshal  []interface{}
-	jsonData      []byte
+	mustUnmarshal        []interface{}
+	mayUnmarshal         []interface{}
+	ignoreKeys           []string
+	additionalProperties interface{}
+	jsonData             []byte
 }
 
 func (u unionMap) unmarshal() error {
@@ -405,5 +375,55 @@ func (u unionMap) unmarshal() error {
 		}
 	}
 
+	if u.additionalProperties == nil {
+		return nil
+	}
+
+	// unmarshal to a generic map
+	var m map[string]*json.RawMessage
+	err := json.Unmarshal(u.jsonData, &m)
+	if err != nil {
+		return err
+	}
+	// removing ignored keys (defined in struct)
+	for _, i := range u.ignoreKeys {
+		delete(m, i)
+	}
+	// returning early on empty map
+	if len(m) == 0 {
+		return nil
+	}
+
+	// Returning early on empty map.
+	if len(m) == 0 {
+		return nil
+	}
+	if u.additionalProperties != nil {
+		return u.unmarshalAdditionalProperties(m)
+	}
+	return nil
+}
+func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) error {
+	var err error
+	subMap := make([]byte, 1, 100)
+	subMap[0] = '{'
+
+	// Iterating map and filling additional properties.
+	for key, val := range m {
+		keyEscaped := `"` + strings.Replace(key, `"`, `\"`, -1) + `":`
+		if len(subMap) != 1 {
+			subMap = append(subMap[:len(subMap)-1], ',')
+		}
+		subMap = append(subMap, []byte(keyEscaped)...)
+		subMap = append(subMap, []byte(*val)...)
+		subMap = append(subMap, '}')
+	}
+
+	if len(subMap) > 1 {
+		err = json.Unmarshal(subMap, u.additionalProperties)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/tests/resources/go/draft7/entities_test.go
+++ b/tests/resources/go/draft7/entities_test.go
@@ -1,0 +1,78 @@
+package entities_test
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"github.com/swaggest/assertjson"
+	"github.com/yudai/gojsondiff/formatter"
+	"io/ioutil"
+	entities "test/draft7"
+	"testing"
+)
+
+func TestSchema_MarshalJSON_roundtrip_asyncapi2(t *testing.T) {
+	data, err := ioutil.ReadFile("../../asyncapi-2.0.0.json")
+	require.NoError(t, err)
+
+	s := entities.Schema{}
+	require.NoError(t, json.Unmarshal(data, &s))
+
+	marshaled, err := json.Marshal(s)
+	require.NoError(t, err)
+	assertjson.Comparer{
+		FormatterConfig: formatter.AsciiFormatterConfig{
+			Coloring: true,
+		},
+	}.Equal(t, data, marshaled)
+}
+
+func TestSchema_MarshalJSON_roundtrip_draft7(t *testing.T) {
+	data, err := ioutil.ReadFile("../../../../vendor/swaggest/json-schema/spec/json-schema-draft7.json")
+	require.NoError(t, err)
+
+	s := entities.Schema{}
+	require.NoError(t, json.Unmarshal(data, &s))
+
+	marshaled, err := json.Marshal(s)
+	require.NoError(t, err)
+	assertjson.Comparer{
+		FormatterConfig: formatter.AsciiFormatterConfig{
+			Coloring: true,
+		},
+	}.Equal(t, data, marshaled)
+}
+
+// Pointers:
+// BenchmarkSchema_UnmarshalJSON-4   	    3699	    311725 ns/op	   98225 B/op	    1256 allocs/op
+// BenchmarkSchema_MarshalJSON-4     	    5398	    216649 ns/op	   45012 B/op	     931 allocs/op
+
+// Values:
+// BenchmarkSchema_UnmarshalJSON-4   	    3667	    315218 ns/op	  104194 B/op	    1217 allocs/op
+// BenchmarkSchema_MarshalJSON-4     	    5157	    212650 ns/op	   44995 B/op	     931 allocs/op
+
+func BenchmarkSchema_UnmarshalJSON(b *testing.B) {
+	data, err := ioutil.ReadFile("../../../../vendor/swaggest/json-schema/spec/json-schema-draft7.json")
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	s := entities.Schema{}
+	for i := 0; i < b.N; i++ {
+		_ = json.Unmarshal(data, &s)
+	}
+}
+
+
+func BenchmarkSchema_MarshalJSON(b *testing.B) {
+	data, err := ioutil.ReadFile("../../../../vendor/swaggest/json-schema/spec/json-schema-draft7.json")
+	require.NoError(b, err)
+	s := entities.Schema{}
+	require.NoError(b, json.Unmarshal(data, &s))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = json.Marshal(&s)
+	}
+}

--- a/tests/resources/go/openapi3/entities.go
+++ b/tests/resources/go/openapi3/entities.go
@@ -15,15 +15,15 @@ import (
 //
 // Validation schema for OpenAPI Specification 3.0.X.
 type OpenAPI struct {
-	Openapi             string                 `json:"openapi,omitempty"`
-	Info                *Info                  `json:"info,omitempty"`
-	ExternalDocs        *ExternalDocumentation `json:"externalDocs,omitempty"`
-	Servers             []Server               `json:"servers,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	Tags                []Tag                  `json:"tags,omitempty"`
-	Paths               *Paths                 `json:"paths,omitempty"`
-	Components          *Components            `json:"components,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Openapi       string                 `json:"openapi,omitempty"`
+	Info          *Info                  `json:"info,omitempty"`
+	ExternalDocs  *ExternalDocumentation `json:"externalDocs,omitempty"`
+	Servers       []Server               `json:"servers,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	Tags          []Tag                  `json:"tags,omitempty"`
+	Paths         *Paths                 `json:"paths,omitempty"`
+	Components    *Components            `json:"components,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalOpenAPI OpenAPI
@@ -45,7 +45,7 @@ func (i *OpenAPI) UnmarshalJSON(data []byte) error {
 			"components",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -58,18 +58,18 @@ func (i *OpenAPI) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OpenAPI) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOpenAPI(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOpenAPI(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/Info".
 type Info struct {
-	Title               string                 `json:"title,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	TermsOfService      string                 `json:"termsOfService,omitempty"`
-	Contact             *Contact               `json:"contact,omitempty"`
-	License             *License               `json:"license,omitempty"`
-	Version             string                 `json:"version,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`
+	Description    string                 `json:"description,omitempty"`
+	TermsOfService string                 `json:"termsOfService,omitempty"`
+	Contact        *Contact               `json:"contact,omitempty"`
+	License        *License               `json:"license,omitempty"`
+	Version        string                 `json:"version,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
@@ -89,7 +89,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"version",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -102,15 +102,15 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/Contact".
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	Email               string                 `json:"email,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	Email         string                 `json:"email,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
@@ -127,7 +127,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -140,14 +140,14 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/License".
 type License struct {
-	Name                string                 `json:"name,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
@@ -163,7 +163,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -176,14 +176,14 @@ func (i *License) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // ExternalDocumentation structure is generated from "#/definitions/ExternalDocumentation".
 type ExternalDocumentation struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocumentation ExternalDocumentation
@@ -199,7 +199,7 @@ func (i *ExternalDocumentation) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -212,15 +212,15 @@ func (i *ExternalDocumentation) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocumentation) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocumentation(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocumentation(i), i.MapOfAnything)
 }
 
 // Server structure is generated from "#/definitions/Server".
 type Server struct {
-	URL                 string                    `json:"url,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	Variables           map[string]ServerVariable `json:"variables,omitempty"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                     // Key must match pattern: ^x-
+	URL           string                    `json:"url,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	Variables     map[string]ServerVariable `json:"variables,omitempty"`
+	MapOfAnything map[string]interface{}    `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServer Server
@@ -237,7 +237,7 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 			"variables",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -250,15 +250,15 @@ func (i *Server) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Server) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServer(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServer(i), i.MapOfAnything)
 }
 
 // ServerVariable structure is generated from "#/definitions/ServerVariable".
 type ServerVariable struct {
-	Enum                []string               `json:"enum,omitempty"`
-	Default             string                 `json:"default,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Enum          []string               `json:"enum,omitempty"`
+	Default       string                 `json:"default,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalServerVariable ServerVariable
@@ -275,7 +275,7 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -288,15 +288,15 @@ func (i *ServerVariable) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ServerVariable) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalServerVariable(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalServerVariable(i), i.MapOfAnything)
 }
 
 // Tag structure is generated from "#/definitions/Tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocumentation `json:"externalDocs,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocumentation `json:"externalDocs,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
@@ -313,7 +313,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -326,7 +326,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // PathItem structure is generated from "#/definitions/PathItem".
@@ -337,7 +337,7 @@ type PathItem struct {
 	Servers              []Server                  `json:"servers,omitempty"`
 	Parameters           []PathItemParametersItems `json:"parameters,omitempty"`
 	MapOfOperationValues map[string]Operation      `json:"-"`                     // Key must match pattern: ^(get|put|post|delete|options|head|patch|trace)$
-	MapOfAnythingValues  map[string]interface{}    `json:"-"`                     // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{}    `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalPathItem PathItem
@@ -357,7 +357,7 @@ func (i *PathItem) UnmarshalJSON(data []byte) error {
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexGetPutPostDeleteOptionsHeadPatchTrace: &ii.MapOfOperationValues, // ^(get|put|post|delete|options|head|patch|trace)$
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -370,7 +370,7 @@ func (i *PathItem) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i PathItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPathItem(i), i.MapOfOperationValues, i.MapOfAnythingValues)
+	return marshalUnion(marshalPathItem(i), i.MapOfOperationValues, i.MapOfAnything)
 }
 
 // Parameter structure is generated from "#/definitions/Parameter".
@@ -390,7 +390,7 @@ type Parameter struct {
 	Examples               map[string]ParameterExamplesAdditionalProperties `json:"examples,omitempty"`
 	SchemaXORContentOneOf1 *SchemaXORContentOneOf1                          `json:"-"`
 	Location               *ParameterLocation                               `json:"-"`
-	MapOfAnythingValues    map[string]interface{}                           `json:"-"`                         // Key must match pattern: ^x-
+	MapOfAnything          map[string]interface{}                           `json:"-"`                         // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
@@ -417,7 +417,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 			"examples",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -430,7 +430,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnythingValues, i.SchemaXORContentOneOf1, i.Location)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything, i.SchemaXORContentOneOf1, i.Location)
 }
 
 // Schema structure is generated from "#/definitions/Schema".
@@ -452,7 +452,7 @@ type Schema struct {
 	Required             []string                                        `json:"required,omitempty"`
 	Enum                 []interface{}                                   `json:"enum,omitempty"`
 	Type                 SchemaType                                      `json:"type,omitempty"`
-	MapOfAnythingValues  map[string]interface{}                          `json:"-"`                              // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{}                          `json:"-"`                              // Key must match pattern: ^x-
 	Not                  *SchemaNot                                      `json:"not,omitempty"`
 	AllOf                []SchemaAllOfItems                              `json:"allOf,omitempty"`
 	OneOf                []SchemaOneOfItems                              `json:"oneOf,omitempty"`
@@ -519,7 +519,7 @@ func (i *Schema) UnmarshalJSON(data []byte) error {
 			"xml",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -532,12 +532,13 @@ func (i *Schema) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Schema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalSchema(i), i.MapOfAnything)
 }
 
 // Reference structure is generated from "#/definitions/Reference".
 type Reference struct {
-	MapOfStringValues map[string]string `json:"-"` // Key must match pattern: ^\$ref$
+	MapOfStringValues    map[string]string      `json:"-"` // Key must match pattern: ^\$ref$
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalReference Reference
@@ -549,6 +550,7 @@ func (i *Reference) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexRef: &i.MapOfStringValues, // ^\$ref$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -557,7 +559,7 @@ func (i *Reference) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Reference) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalReference(i), i.MapOfStringValues)
+	return marshalUnion(marshalReference(i), i.MapOfStringValues, i.AdditionalProperties)
 }
 
 // SchemaNot structure is generated from "#/definitions/Schema->not".
@@ -776,18 +778,46 @@ func (i SchemaAdditionalProperties) MarshalJSON() ([]byte, error) {
 
 // Discriminator structure is generated from "#/definitions/Discriminator".
 type Discriminator struct {
-	PropertyName string            `json:"propertyName,omitempty"`
-	Mapping      map[string]string `json:"mapping,omitempty"`
+	PropertyName         string                 `json:"propertyName,omitempty"`
+	Mapping              map[string]string      `json:"mapping,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`                      // All unmatched properties
+}
+
+type marshalDiscriminator Discriminator
+
+// UnmarshalJSON decodes JSON.
+func (i *Discriminator) UnmarshalJSON(data []byte) error {
+	ii := marshalDiscriminator(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"propertyName",
+			"mapping",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Discriminator(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Discriminator) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalDiscriminator(i), i.AdditionalProperties)
 }
 
 // XML structure is generated from "#/definitions/XML".
 type XML struct {
-	Name                string                 `json:"name,omitempty"`
-	Namespace           string                 `json:"namespace,omitempty"`
-	Prefix              string                 `json:"prefix,omitempty"`
-	Attribute           bool                   `json:"attribute,omitempty"`
-	Wrapped             bool                   `json:"wrapped,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                   // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Namespace     string                 `json:"namespace,omitempty"`
+	Prefix        string                 `json:"prefix,omitempty"`
+	Attribute     bool                   `json:"attribute,omitempty"`
+	Wrapped       bool                   `json:"wrapped,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                   // Key must match pattern: ^x-
 }
 
 type marshalXML XML
@@ -806,7 +836,7 @@ func (i *XML) UnmarshalJSON(data []byte) error {
 			"wrapped",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -819,7 +849,7 @@ func (i *XML) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i XML) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalXML(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalXML(i), i.MapOfAnything)
 }
 
 // ParameterSchema structure is generated from "#/definitions/Parameter->schema".
@@ -854,11 +884,11 @@ func (i ParameterSchema) MarshalJSON() ([]byte, error) {
 
 // MediaType structure is generated from "#/definitions/MediaType".
 type MediaType struct {
-	Schema              *MediaTypeSchema                                 `json:"schema,omitempty"`
-	Example             interface{}                                      `json:"example,omitempty"`
-	Examples            map[string]MediaTypeExamplesAdditionalProperties `json:"examples,omitempty"`
-	MapOfAnythingValues map[string]interface{}                           `json:"-"`                  // Key must match pattern: ^x-
-	Encoding            map[string]Encoding                              `json:"encoding,omitempty"`
+	Schema        *MediaTypeSchema                                 `json:"schema,omitempty"`
+	Example       interface{}                                      `json:"example,omitempty"`
+	Examples      map[string]MediaTypeExamplesAdditionalProperties `json:"examples,omitempty"`
+	MapOfAnything map[string]interface{}                           `json:"-"`                  // Key must match pattern: ^x-
+	Encoding      map[string]Encoding                              `json:"encoding,omitempty"`
 }
 
 type marshalMediaType MediaType
@@ -876,7 +906,7 @@ func (i *MediaType) UnmarshalJSON(data []byte) error {
 			"encoding",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -889,7 +919,7 @@ func (i *MediaType) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i MediaType) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMediaType(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalMediaType(i), i.MapOfAnything)
 }
 
 // MediaTypeSchema structure is generated from "#/definitions/MediaType->schema".
@@ -924,11 +954,11 @@ func (i MediaTypeSchema) MarshalJSON() ([]byte, error) {
 
 // Example structure is generated from "#/definitions/Example".
 type Example struct {
-	Summary             string                 `json:"summary,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	Value               interface{}            `json:"value,omitempty"`
-	ExternalValue       string                 `json:"externalValue,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                       // Key must match pattern: ^x-
+	Summary       string                 `json:"summary,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Value         interface{}            `json:"value,omitempty"`
+	ExternalValue string                 `json:"externalValue,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                       // Key must match pattern: ^x-
 }
 
 type marshalExample Example
@@ -946,7 +976,7 @@ func (i *Example) UnmarshalJSON(data []byte) error {
 			"externalValue",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -959,7 +989,7 @@ func (i *Example) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Example) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExample(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExample(i), i.MapOfAnything)
 }
 
 // MediaTypeExamplesAdditionalProperties structure is generated from "#/definitions/MediaType->examples->additionalProperties".
@@ -1003,17 +1033,17 @@ type Encoding struct {
 
 // Header structure is generated from "#/definitions/Header".
 type Header struct {
-	Description         string                                        `json:"description,omitempty"`
-	Required            bool                                          `json:"required,omitempty"`
-	Deprecated          bool                                          `json:"deprecated,omitempty"`
-	AllowEmptyValue     bool                                          `json:"allowEmptyValue,omitempty"`
-	Explode             bool                                          `json:"explode,omitempty"`
-	AllowReserved       bool                                          `json:"allowReserved,omitempty"`
-	Schema              *HeaderSchema                                 `json:"schema,omitempty"`
-	Content             map[string]MediaType                          `json:"content,omitempty"`
-	Example             interface{}                                   `json:"example,omitempty"`
-	Examples            map[string]HeaderExamplesAdditionalProperties `json:"examples,omitempty"`
-	MapOfAnythingValues map[string]interface{}                        `json:"-"`                         // Key must match pattern: ^x-
+	Description     string                                        `json:"description,omitempty"`
+	Required        bool                                          `json:"required,omitempty"`
+	Deprecated      bool                                          `json:"deprecated,omitempty"`
+	AllowEmptyValue bool                                          `json:"allowEmptyValue,omitempty"`
+	Explode         bool                                          `json:"explode,omitempty"`
+	AllowReserved   bool                                          `json:"allowReserved,omitempty"`
+	Schema          *HeaderSchema                                 `json:"schema,omitempty"`
+	Content         map[string]MediaType                          `json:"content,omitempty"`
+	Example         interface{}                                   `json:"example,omitempty"`
+	Examples        map[string]HeaderExamplesAdditionalProperties `json:"examples,omitempty"`
+	MapOfAnything   map[string]interface{}                        `json:"-"`                         // Key must match pattern: ^x-
 }
 
 type marshalHeader Header
@@ -1037,9 +1067,10 @@ func (i *Header) UnmarshalJSON(data []byte) error {
 			"content",
 			"example",
 			"examples",
+			"style",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1060,7 +1091,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Header) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constHeader, marshalHeader(i), i.MapOfAnythingValues)
+	return marshalUnion(constHeader, marshalHeader(i), i.MapOfAnything)
 }
 
 // HeaderSchema structure is generated from "#/definitions/Header->schema".
@@ -1164,7 +1195,8 @@ func (i ParameterExamplesAdditionalProperties) MarshalJSON() ([]byte, error) {
 //
 // Parameter in path.
 type ParameterLocationOneOf0 struct {
-	Style ParameterLocationOneOf0Style `json:"style,omitempty"`
+	Style                ParameterLocationOneOf0Style `json:"style,omitempty"`
+	AdditionalProperties map[string]interface{}       `json:"-"`               // All unmatched properties
 }
 
 type marshalParameterLocationOneOf0 ParameterLocationOneOf0
@@ -1177,6 +1209,12 @@ func (i *ParameterLocationOneOf0) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mustUnmarshal: []interface{}{&ii},
 		mayUnmarshal: mayUnmarshal,
+		ignoreKeys: []string{
+			"style",
+			"in",
+			"required",
+		},
+		additionalProperties: &ii.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["in"]; !ok || string(v) != `"path"` {
@@ -1199,14 +1237,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i ParameterLocationOneOf0) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constParameterLocationOneOf0, marshalParameterLocationOneOf0(i))
+	return marshalUnion(constParameterLocationOneOf0, marshalParameterLocationOneOf0(i), i.AdditionalProperties)
 }
 
 // ParameterLocationOneOf1 structure is generated from "#/definitions/ParameterLocation/oneOf/1".
 //
 // Parameter in query.
 type ParameterLocationOneOf1 struct {
-	Style ParameterLocationOneOf1Style `json:"style,omitempty"`
+	Style                ParameterLocationOneOf1Style `json:"style,omitempty"`
+	AdditionalProperties map[string]interface{}       `json:"-"`               // All unmatched properties
 }
 
 type marshalParameterLocationOneOf1 ParameterLocationOneOf1
@@ -1219,6 +1258,11 @@ func (i *ParameterLocationOneOf1) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mustUnmarshal: []interface{}{&ii},
 		mayUnmarshal: mayUnmarshal,
+		ignoreKeys: []string{
+			"style",
+			"in",
+		},
+		additionalProperties: &ii.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["in"]; !ok || string(v) != `"query"` {
@@ -1238,14 +1282,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i ParameterLocationOneOf1) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constParameterLocationOneOf1, marshalParameterLocationOneOf1(i))
+	return marshalUnion(constParameterLocationOneOf1, marshalParameterLocationOneOf1(i), i.AdditionalProperties)
 }
 
 // ParameterLocationOneOf2 structure is generated from "#/definitions/ParameterLocation/oneOf/2".
 //
 // Parameter in header.
 type ParameterLocationOneOf2 struct {
-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalParameterLocationOneOf2 ParameterLocationOneOf2
@@ -1256,6 +1300,7 @@ func (i *ParameterLocationOneOf2) UnmarshalJSON(data []byte) error {
 	mayUnmarshal := []interface{}{&constValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["in"]; !ok || string(v) != `"header"` {
@@ -1275,14 +1320,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i ParameterLocationOneOf2) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constParameterLocationOneOf2, marshalParameterLocationOneOf2(i))
+	return marshalUnion(constParameterLocationOneOf2, marshalParameterLocationOneOf2(i), i.AdditionalProperties)
 }
 
 // ParameterLocationOneOf3 structure is generated from "#/definitions/ParameterLocation/oneOf/3".
 //
 // Parameter in cookie.
 type ParameterLocationOneOf3 struct {
-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalParameterLocationOneOf3 ParameterLocationOneOf3
@@ -1293,6 +1338,7 @@ func (i *ParameterLocationOneOf3) UnmarshalJSON(data []byte) error {
 	mayUnmarshal := []interface{}{&constValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["in"]; !ok || string(v) != `"cookie"` {
@@ -1312,7 +1358,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i ParameterLocationOneOf3) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constParameterLocationOneOf3, marshalParameterLocationOneOf3(i))
+	return marshalUnion(constParameterLocationOneOf3, marshalParameterLocationOneOf3(i), i.AdditionalProperties)
 }
 
 // ParameterLocation structure is generated from "#/definitions/ParameterLocation".
@@ -1387,19 +1433,19 @@ func (i PathItemParametersItems) MarshalJSON() ([]byte, error) {
 
 // Operation structure is generated from "#/definitions/Operation".
 type Operation struct {
-	Tags                []string                                          `json:"tags,omitempty"`
-	Summary             string                                            `json:"summary,omitempty"`
-	Description         string                                            `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocumentation                            `json:"externalDocs,omitempty"`
-	ID                  string                                            `json:"operationId,omitempty"`
-	Parameters          []OperationParametersItems                        `json:"parameters,omitempty"`
-	RequestBody         *OperationRequestBody                             `json:"requestBody,omitempty"`
-	Responses           *Responses                                        `json:"responses,omitempty"`
-	MapOfAnythingValues map[string]interface{}                            `json:"-"`                      // Key must match pattern: ^x-
-	Callbacks           map[string]OperationCallbacksAdditionalProperties `json:"callbacks,omitempty"`
-	Deprecated          bool                                              `json:"deprecated,omitempty"`
-	Security            []map[string][]string                             `json:"security,omitempty"`
-	Servers             []Server                                          `json:"servers,omitempty"`
+	Tags          []string                                          `json:"tags,omitempty"`
+	Summary       string                                            `json:"summary,omitempty"`
+	Description   string                                            `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocumentation                            `json:"externalDocs,omitempty"`
+	ID            string                                            `json:"operationId,omitempty"`
+	Parameters    []OperationParametersItems                        `json:"parameters,omitempty"`
+	RequestBody   *OperationRequestBody                             `json:"requestBody,omitempty"`
+	Responses     *Responses                                        `json:"responses,omitempty"`
+	MapOfAnything map[string]interface{}                            `json:"-"`                      // Key must match pattern: ^x-
+	Callbacks     map[string]OperationCallbacksAdditionalProperties `json:"callbacks,omitempty"`
+	Deprecated    bool                                              `json:"deprecated,omitempty"`
+	Security      []map[string][]string                             `json:"security,omitempty"`
+	Servers       []Server                                          `json:"servers,omitempty"`
 }
 
 type marshalOperation Operation
@@ -1425,7 +1471,7 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 			"servers",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1438,7 +1484,7 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Operation) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperation(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperation(i), i.MapOfAnything)
 }
 
 // OperationParametersItems structure is generated from "#/definitions/Operation->parameters->items".
@@ -1473,10 +1519,10 @@ func (i OperationParametersItems) MarshalJSON() ([]byte, error) {
 
 // RequestBody structure is generated from "#/definitions/RequestBody".
 type RequestBody struct {
-	Description         string                 `json:"description,omitempty"`
-	Content             map[string]MediaType   `json:"content,omitempty"`
-	Required            bool                   `json:"required,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	Content       map[string]MediaType   `json:"content,omitempty"`
+	Required      bool                   `json:"required,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalRequestBody RequestBody
@@ -1493,7 +1539,7 @@ func (i *RequestBody) UnmarshalJSON(data []byte) error {
 			"required",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1506,7 +1552,7 @@ func (i *RequestBody) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i RequestBody) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalRequestBody(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalRequestBody(i), i.MapOfAnything)
 }
 
 // OperationRequestBody structure is generated from "#/definitions/Operation->requestBody".
@@ -1543,7 +1589,7 @@ func (i OperationRequestBody) MarshalJSON() ([]byte, error) {
 type Responses struct {
 	Default                    *ResponsesDefault          `json:"default,omitempty"`
 	MapOfResponses15D2XXValues map[string]Responses15D2XX `json:"-"`                 // Key must match pattern: ^[1-5](?:\d{2}|XX)$
-	MapOfAnythingValues        map[string]interface{}     `json:"-"`                 // Key must match pattern: ^x-
+	MapOfAnything              map[string]interface{}     `json:"-"`                 // Key must match pattern: ^x-
 }
 
 type marshalResponses Responses
@@ -1559,7 +1605,7 @@ func (i *Responses) UnmarshalJSON(data []byte) error {
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regex15D2XX: &ii.MapOfResponses15D2XXValues, // ^[1-5](?:\d{2}|XX)$
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1572,16 +1618,16 @@ func (i *Responses) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Responses) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalResponses(i), i.MapOfResponses15D2XXValues, i.MapOfAnythingValues)
+	return marshalUnion(marshalResponses(i), i.MapOfResponses15D2XXValues, i.MapOfAnything)
 }
 
 // Response structure is generated from "#/definitions/Response".
 type Response struct {
-	Description         string                                         `json:"description,omitempty"`
-	Headers             map[string]ResponseHeadersAdditionalProperties `json:"headers,omitempty"`
-	Content             map[string]MediaType                           `json:"content,omitempty"`
-	Links               map[string]ResponseLinksAdditionalProperties   `json:"links,omitempty"`
-	MapOfAnythingValues map[string]interface{}                         `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                                         `json:"description,omitempty"`
+	Headers       map[string]ResponseHeadersAdditionalProperties `json:"headers,omitempty"`
+	Content       map[string]MediaType                           `json:"content,omitempty"`
+	Links         map[string]ResponseLinksAdditionalProperties   `json:"links,omitempty"`
+	MapOfAnything map[string]interface{}                         `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalResponse Response
@@ -1599,7 +1645,7 @@ func (i *Response) UnmarshalJSON(data []byte) error {
 			"links",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1612,7 +1658,7 @@ func (i *Response) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Response) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalResponse(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalResponse(i), i.MapOfAnything)
 }
 
 // ResponseHeadersAdditionalProperties structure is generated from "#/definitions/Response->headers->additionalProperties".
@@ -1647,13 +1693,13 @@ func (i ResponseHeadersAdditionalProperties) MarshalJSON() ([]byte, error) {
 
 // Link structure is generated from "#/definitions/Link".
 type Link struct {
-	OperationID         string                 `json:"operationId,omitempty"`
-	OperationRef        string                 `json:"operationRef,omitempty"`
-	Parameters          map[string]interface{} `json:"parameters,omitempty"`
-	RequestBody         interface{}            `json:"requestBody,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	Server              *Server                `json:"server,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	OperationID   string                 `json:"operationId,omitempty"`
+	OperationRef  string                 `json:"operationRef,omitempty"`
+	Parameters    map[string]interface{} `json:"parameters,omitempty"`
+	RequestBody   interface{}            `json:"requestBody,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Server        *Server                `json:"server,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalLink Link
@@ -1673,7 +1719,7 @@ func (i *Link) UnmarshalJSON(data []byte) error {
 			"server",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1686,7 +1732,7 @@ func (i *Link) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Link) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLink(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLink(i), i.MapOfAnything)
 }
 
 // ResponseLinksAdditionalProperties structure is generated from "#/definitions/Response->links->additionalProperties".
@@ -1781,8 +1827,8 @@ func (i Responses15D2XX) MarshalJSON() ([]byte, error) {
 
 // Callback structure is generated from "#/definitions/Callback".
 type Callback struct {
-	MapOfAnythingValues  map[string]interface{} `json:"-"` // Key must match pattern: ^x-
-	AdditionalProperties map[string]PathItem    `json:"-"`
+	MapOfAnything        map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	AdditionalProperties map[string]PathItem    `json:"-"` // All unmatched properties
 }
 
 type marshalCallback Callback
@@ -1792,7 +1838,7 @@ func (i *Callback) UnmarshalJSON(data []byte) error {
 
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
 		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
@@ -1803,7 +1849,7 @@ func (i *Callback) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Callback) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalCallback(i), i.MapOfAnythingValues, i.AdditionalProperties)
+	return marshalUnion(marshalCallback(i), i.MapOfAnything, i.AdditionalProperties)
 }
 
 // OperationCallbacksAdditionalProperties structure is generated from "#/definitions/Operation->callbacks->additionalProperties".
@@ -1839,7 +1885,7 @@ func (i OperationCallbacksAdditionalProperties) MarshalJSON() ([]byte, error) {
 // Paths structure is generated from "#/definitions/Paths".
 type Paths struct {
 	MapOfPathItemValues map[string]PathItem    `json:"-"` // Key must match pattern: ^\/
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything       map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 }
 
 type marshalPaths Paths
@@ -1850,7 +1896,7 @@ func (i *Paths) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regex: &i.MapOfPathItemValues, // ^\/
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1860,21 +1906,21 @@ func (i *Paths) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Paths) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPaths(i), i.MapOfPathItemValues, i.MapOfAnythingValues)
+	return marshalUnion(marshalPaths(i), i.MapOfPathItemValues, i.MapOfAnything)
 }
 
 // Components structure is generated from "#/definitions/Components".
 type Components struct {
-	Schemas             *ComponentsSchemas         `json:"schemas,omitempty"`
-	Responses           *ComponentsResponses       `json:"responses,omitempty"`
-	Parameters          *ComponentsParameters      `json:"parameters,omitempty"`
-	Examples            *ComponentsExamples        `json:"examples,omitempty"`
-	RequestBodies       *ComponentsRequestBodies   `json:"requestBodies,omitempty"`
-	Headers             *ComponentsHeaders         `json:"headers,omitempty"`
-	SecuritySchemes     *ComponentsSecuritySchemes `json:"securitySchemes,omitempty"`
-	Links               *ComponentsLinks           `json:"links,omitempty"`
-	Callbacks           *ComponentsCallbacks       `json:"callbacks,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                         // Key must match pattern: ^x-
+	Schemas         *ComponentsSchemas         `json:"schemas,omitempty"`
+	Responses       *ComponentsResponses       `json:"responses,omitempty"`
+	Parameters      *ComponentsParameters      `json:"parameters,omitempty"`
+	Examples        *ComponentsExamples        `json:"examples,omitempty"`
+	RequestBodies   *ComponentsRequestBodies   `json:"requestBodies,omitempty"`
+	Headers         *ComponentsHeaders         `json:"headers,omitempty"`
+	SecuritySchemes *ComponentsSecuritySchemes `json:"securitySchemes,omitempty"`
+	Links           *ComponentsLinks           `json:"links,omitempty"`
+	Callbacks       *ComponentsCallbacks       `json:"callbacks,omitempty"`
+	MapOfAnything   map[string]interface{}     `json:"-"`                         // Key must match pattern: ^x-
 }
 
 type marshalComponents Components
@@ -1897,7 +1943,7 @@ func (i *Components) UnmarshalJSON(data []byte) error {
 			"callbacks",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1910,7 +1956,7 @@ func (i *Components) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Components) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponents(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalComponents(i), i.MapOfAnything)
 }
 
 // ComponentsSchemasAZAZ09 structure is generated from "#/definitions/Components->schemas->^[a-zA-Z0-9\.\-_]+$".
@@ -1946,6 +1992,7 @@ func (i ComponentsSchemasAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsSchemas structure is generated from "#/definitions/Components->schemas".
 type ComponentsSchemas struct {
 	MapOfComponentsSchemasAZAZ09Values map[string]ComponentsSchemasAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties               map[string]interface{}             `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSchemas ComponentsSchemas
@@ -1957,6 +2004,7 @@ func (i *ComponentsSchemas) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsSchemasAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -1965,7 +2013,7 @@ func (i *ComponentsSchemas) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSchemas) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSchemas(i), i.MapOfComponentsSchemasAZAZ09Values)
+	return marshalUnion(marshalComponentsSchemas(i), i.MapOfComponentsSchemasAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsResponsesAZAZ09 structure is generated from "#/definitions/Components->responses->^[a-zA-Z0-9\.\-_]+$".
@@ -2001,6 +2049,7 @@ func (i ComponentsResponsesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsResponses structure is generated from "#/definitions/Components->responses".
 type ComponentsResponses struct {
 	MapOfComponentsResponsesAZAZ09Values map[string]ComponentsResponsesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                 map[string]interface{}               `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsResponses ComponentsResponses
@@ -2012,6 +2061,7 @@ func (i *ComponentsResponses) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsResponsesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2020,7 +2070,7 @@ func (i *ComponentsResponses) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsResponses) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsResponses(i), i.MapOfComponentsResponsesAZAZ09Values)
+	return marshalUnion(marshalComponentsResponses(i), i.MapOfComponentsResponsesAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsParametersAZAZ09 structure is generated from "#/definitions/Components->parameters->^[a-zA-Z0-9\.\-_]+$".
@@ -2056,6 +2106,7 @@ func (i ComponentsParametersAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsParameters structure is generated from "#/definitions/Components->parameters".
 type ComponentsParameters struct {
 	MapOfComponentsParametersAZAZ09Values map[string]ComponentsParametersAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                  map[string]interface{}                `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsParameters ComponentsParameters
@@ -2067,6 +2118,7 @@ func (i *ComponentsParameters) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsParametersAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2075,7 +2127,7 @@ func (i *ComponentsParameters) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsParameters) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsParameters(i), i.MapOfComponentsParametersAZAZ09Values)
+	return marshalUnion(marshalComponentsParameters(i), i.MapOfComponentsParametersAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsExamplesAZAZ09 structure is generated from "#/definitions/Components->examples->^[a-zA-Z0-9\.\-_]+$".
@@ -2111,6 +2163,7 @@ func (i ComponentsExamplesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsExamples structure is generated from "#/definitions/Components->examples".
 type ComponentsExamples struct {
 	MapOfComponentsExamplesAZAZ09Values map[string]ComponentsExamplesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                map[string]interface{}              `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsExamples ComponentsExamples
@@ -2122,6 +2175,7 @@ func (i *ComponentsExamples) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsExamplesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2130,7 +2184,7 @@ func (i *ComponentsExamples) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsExamples) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsExamples(i), i.MapOfComponentsExamplesAZAZ09Values)
+	return marshalUnion(marshalComponentsExamples(i), i.MapOfComponentsExamplesAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsRequestBodiesAZAZ09 structure is generated from "#/definitions/Components->requestBodies->^[a-zA-Z0-9\.\-_]+$".
@@ -2166,6 +2220,7 @@ func (i ComponentsRequestBodiesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsRequestBodies structure is generated from "#/definitions/Components->requestBodies".
 type ComponentsRequestBodies struct {
 	MapOfComponentsRequestBodiesAZAZ09Values map[string]ComponentsRequestBodiesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                     map[string]interface{}                   `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsRequestBodies ComponentsRequestBodies
@@ -2177,6 +2232,7 @@ func (i *ComponentsRequestBodies) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsRequestBodiesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2185,7 +2241,7 @@ func (i *ComponentsRequestBodies) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsRequestBodies) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsRequestBodies(i), i.MapOfComponentsRequestBodiesAZAZ09Values)
+	return marshalUnion(marshalComponentsRequestBodies(i), i.MapOfComponentsRequestBodiesAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsHeadersAZAZ09 structure is generated from "#/definitions/Components->headers->^[a-zA-Z0-9\.\-_]+$".
@@ -2221,6 +2277,7 @@ func (i ComponentsHeadersAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsHeaders structure is generated from "#/definitions/Components->headers".
 type ComponentsHeaders struct {
 	MapOfComponentsHeadersAZAZ09Values map[string]ComponentsHeadersAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties               map[string]interface{}             `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsHeaders ComponentsHeaders
@@ -2232,6 +2289,7 @@ func (i *ComponentsHeaders) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsHeadersAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2240,15 +2298,15 @@ func (i *ComponentsHeaders) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsHeaders) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsHeaders(i), i.MapOfComponentsHeadersAZAZ09Values)
+	return marshalUnion(marshalComponentsHeaders(i), i.MapOfComponentsHeadersAZAZ09Values, i.AdditionalProperties)
 }
 
 // APIKeySecurityScheme structure is generated from "#/definitions/APIKeySecurityScheme".
 type APIKeySecurityScheme struct {
-	Name                string                 `json:"name,omitempty"`
-	In                  APIKeySecuritySchemeIn `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	In            APIKeySecuritySchemeIn `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeySecurityScheme APIKeySecurityScheme
@@ -2265,9 +2323,10 @@ func (i *APIKeySecurityScheme) UnmarshalJSON(data []byte) error {
 			"name",
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2288,17 +2347,17 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKeySecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKeySecurityScheme, marshalAPIKeySecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKeySecurityScheme, marshalAPIKeySecurityScheme(i), i.MapOfAnything)
 }
 
 // HTTPSecurityScheme structure is generated from "#/definitions/HTTPSecurityScheme".
 type HTTPSecurityScheme struct {
-	Scheme              string                    `json:"scheme,omitempty"`
-	BearerFormat        string                    `json:"bearerFormat,omitempty"`
-	Description         string                    `json:"description,omitempty"`
-	OneOf0              *HTTPSecuritySchemeOneOf0 `json:"-"`
-	OneOf1              *HTTPSecuritySchemeOneOf1 `json:"-"`
-	MapOfAnythingValues map[string]interface{}    `json:"-"`                      // Key must match pattern: ^x-
+	Scheme        string                    `json:"scheme,omitempty"`
+	BearerFormat  string                    `json:"bearerFormat,omitempty"`
+	Description   string                    `json:"description,omitempty"`
+	OneOf0        *HTTPSecuritySchemeOneOf0 `json:"-"`
+	OneOf1        *HTTPSecuritySchemeOneOf1 `json:"-"`
+	MapOfAnything map[string]interface{}    `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalHTTPSecurityScheme HTTPSecurityScheme
@@ -2315,9 +2374,10 @@ func (i *HTTPSecurityScheme) UnmarshalJSON(data []byte) error {
 			"scheme",
 			"bearerFormat",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2344,14 +2404,14 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i HTTPSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constHTTPSecurityScheme, marshalHTTPSecurityScheme(i), i.MapOfAnythingValues, i.OneOf0, i.OneOf1)
+	return marshalUnion(constHTTPSecurityScheme, marshalHTTPSecurityScheme(i), i.MapOfAnything, i.OneOf0, i.OneOf1)
 }
 
 // HTTPSecuritySchemeOneOf0 structure is generated from "#/definitions/HTTPSecurityScheme/oneOf/0".
 //
 // Bearer.
 type HTTPSecuritySchemeOneOf0 struct {
-
+	AdditionalProperties map[string]interface{} `json:"-"` // All unmatched properties
 }
 
 type marshalHTTPSecuritySchemeOneOf0 HTTPSecuritySchemeOneOf0
@@ -2362,6 +2422,7 @@ func (i *HTTPSecuritySchemeOneOf0) UnmarshalJSON(data []byte) error {
 	mayUnmarshal := []interface{}{&constValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 	if v, ok := constValues["scheme"]; !ok || string(v) != `"bearer"` {
@@ -2378,21 +2439,48 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i HTTPSecuritySchemeOneOf0) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constHTTPSecuritySchemeOneOf0, marshalHTTPSecuritySchemeOneOf0(i))
+	return marshalUnion(constHTTPSecuritySchemeOneOf0, marshalHTTPSecuritySchemeOneOf0(i), i.AdditionalProperties)
 }
 
 // HTTPSecuritySchemeOneOf1 structure is generated from "#/definitions/HTTPSecurityScheme/oneOf/1".
 //
 // Non Bearer.
 type HTTPSecuritySchemeOneOf1 struct {
-	Scheme interface{} `json:"scheme,omitempty"`
+	Scheme               interface{}            `json:"scheme,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`                // All unmatched properties
+}
+
+type marshalHTTPSecuritySchemeOneOf1 HTTPSecuritySchemeOneOf1
+
+// UnmarshalJSON decodes JSON.
+func (i *HTTPSecuritySchemeOneOf1) UnmarshalJSON(data []byte) error {
+	ii := marshalHTTPSecuritySchemeOneOf1(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"scheme",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = HTTPSecuritySchemeOneOf1(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i HTTPSecuritySchemeOneOf1) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalHTTPSecuritySchemeOneOf1(i), i.AdditionalProperties)
 }
 
 // OAuth2SecurityScheme structure is generated from "#/definitions/OAuth2SecurityScheme".
 type OAuth2SecurityScheme struct {
-	Flows               *OAuthFlows            `json:"flows,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Flows         *OAuthFlows            `json:"flows,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalOAuth2SecurityScheme OAuth2SecurityScheme
@@ -2408,9 +2496,10 @@ func (i *OAuth2SecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"flows",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2431,16 +2520,16 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i OAuth2SecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOAuth2SecurityScheme, marshalOAuth2SecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constOAuth2SecurityScheme, marshalOAuth2SecurityScheme(i), i.MapOfAnything)
 }
 
 // OAuthFlows structure is generated from "#/definitions/OAuthFlows".
 type OAuthFlows struct {
-	Implicit            *ImplicitOAuthFlow          `json:"implicit,omitempty"`
-	Password            *PasswordOAuthFlow          `json:"password,omitempty"`
-	ClientCredentials   *ClientCredentialsFlow      `json:"clientCredentials,omitempty"`
-	AuthorizationCode   *AuthorizationCodeOAuthFlow `json:"authorizationCode,omitempty"`
-	MapOfAnythingValues map[string]interface{}      `json:"-"`                           // Key must match pattern: ^x-
+	Implicit          *ImplicitOAuthFlow          `json:"implicit,omitempty"`
+	Password          *PasswordOAuthFlow          `json:"password,omitempty"`
+	ClientCredentials *ClientCredentialsFlow      `json:"clientCredentials,omitempty"`
+	AuthorizationCode *AuthorizationCodeOAuthFlow `json:"authorizationCode,omitempty"`
+	MapOfAnything     map[string]interface{}      `json:"-"`                           // Key must match pattern: ^x-
 }
 
 type marshalOAuthFlows OAuthFlows
@@ -2458,7 +2547,7 @@ func (i *OAuthFlows) UnmarshalJSON(data []byte) error {
 			"authorizationCode",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2471,15 +2560,15 @@ func (i *OAuthFlows) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i OAuthFlows) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOAuthFlows(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOAuthFlows(i), i.MapOfAnything)
 }
 
 // ImplicitOAuthFlow structure is generated from "#/definitions/ImplicitOAuthFlow".
 type ImplicitOAuthFlow struct {
-	AuthorizationURL    string                 `json:"authorizationUrl,omitempty"`
-	RefreshURL          string                 `json:"refreshUrl,omitempty"`
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	AuthorizationURL string                 `json:"authorizationUrl,omitempty"`
+	RefreshURL       string                 `json:"refreshUrl,omitempty"`
+	Scopes           map[string]string      `json:"scopes,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalImplicitOAuthFlow ImplicitOAuthFlow
@@ -2496,7 +2585,7 @@ func (i *ImplicitOAuthFlow) UnmarshalJSON(data []byte) error {
 			"scopes",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2509,15 +2598,15 @@ func (i *ImplicitOAuthFlow) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ImplicitOAuthFlow) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalImplicitOAuthFlow(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalImplicitOAuthFlow(i), i.MapOfAnything)
 }
 
 // PasswordOAuthFlow structure is generated from "#/definitions/PasswordOAuthFlow".
 type PasswordOAuthFlow struct {
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	RefreshURL          string                 `json:"refreshUrl,omitempty"`
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	TokenURL      string                 `json:"tokenUrl,omitempty"`
+	RefreshURL    string                 `json:"refreshUrl,omitempty"`
+	Scopes        map[string]string      `json:"scopes,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalPasswordOAuthFlow PasswordOAuthFlow
@@ -2534,7 +2623,7 @@ func (i *PasswordOAuthFlow) UnmarshalJSON(data []byte) error {
 			"scopes",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2547,15 +2636,15 @@ func (i *PasswordOAuthFlow) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i PasswordOAuthFlow) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPasswordOAuthFlow(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalPasswordOAuthFlow(i), i.MapOfAnything)
 }
 
 // ClientCredentialsFlow structure is generated from "#/definitions/ClientCredentialsFlow".
 type ClientCredentialsFlow struct {
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	RefreshURL          string                 `json:"refreshUrl,omitempty"`
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	TokenURL      string                 `json:"tokenUrl,omitempty"`
+	RefreshURL    string                 `json:"refreshUrl,omitempty"`
+	Scopes        map[string]string      `json:"scopes,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalClientCredentialsFlow ClientCredentialsFlow
@@ -2572,7 +2661,7 @@ func (i *ClientCredentialsFlow) UnmarshalJSON(data []byte) error {
 			"scopes",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2585,16 +2674,16 @@ func (i *ClientCredentialsFlow) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ClientCredentialsFlow) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalClientCredentialsFlow(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalClientCredentialsFlow(i), i.MapOfAnything)
 }
 
 // AuthorizationCodeOAuthFlow structure is generated from "#/definitions/AuthorizationCodeOAuthFlow".
 type AuthorizationCodeOAuthFlow struct {
-	AuthorizationURL    string                 `json:"authorizationUrl,omitempty"`
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	RefreshURL          string                 `json:"refreshUrl,omitempty"`
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	AuthorizationURL string                 `json:"authorizationUrl,omitempty"`
+	TokenURL         string                 `json:"tokenUrl,omitempty"`
+	RefreshURL       string                 `json:"refreshUrl,omitempty"`
+	Scopes           map[string]string      `json:"scopes,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalAuthorizationCodeOAuthFlow AuthorizationCodeOAuthFlow
@@ -2612,7 +2701,7 @@ func (i *AuthorizationCodeOAuthFlow) UnmarshalJSON(data []byte) error {
 			"scopes",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2625,14 +2714,14 @@ func (i *AuthorizationCodeOAuthFlow) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i AuthorizationCodeOAuthFlow) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalAuthorizationCodeOAuthFlow(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalAuthorizationCodeOAuthFlow(i), i.MapOfAnything)
 }
 
 // OpenIDConnectSecurityScheme structure is generated from "#/definitions/OpenIdConnectSecurityScheme".
 type OpenIDConnectSecurityScheme struct {
-	OpenIDConnectURL    string                 `json:"openIdConnectUrl,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	OpenIDConnectURL string                 `json:"openIdConnectUrl,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalOpenIDConnectSecurityScheme OpenIDConnectSecurityScheme
@@ -2648,9 +2737,10 @@ func (i *OpenIDConnectSecurityScheme) UnmarshalJSON(data []byte) error {
 		ignoreKeys: []string{
 			"openIdConnectUrl",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -2671,7 +2761,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i OpenIDConnectSecurityScheme) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOpenIDConnectSecurityScheme, marshalOpenIDConnectSecurityScheme(i), i.MapOfAnythingValues)
+	return marshalUnion(constOpenIDConnectSecurityScheme, marshalOpenIDConnectSecurityScheme(i), i.MapOfAnything)
 }
 
 // SecurityScheme structure is generated from "#/definitions/SecurityScheme".
@@ -2745,6 +2835,7 @@ func (i ComponentsSecuritySchemesAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsSecuritySchemes structure is generated from "#/definitions/Components->securitySchemes".
 type ComponentsSecuritySchemes struct {
 	MapOfComponentsSecuritySchemesAZAZ09Values map[string]ComponentsSecuritySchemesAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                       map[string]interface{}                     `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsSecuritySchemes ComponentsSecuritySchemes
@@ -2756,6 +2847,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsSecuritySchemesAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2764,7 +2856,7 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values)
+	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsLinksAZAZ09 structure is generated from "#/definitions/Components->links->^[a-zA-Z0-9\.\-_]+$".
@@ -2800,6 +2892,7 @@ func (i ComponentsLinksAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsLinks structure is generated from "#/definitions/Components->links".
 type ComponentsLinks struct {
 	MapOfComponentsLinksAZAZ09Values map[string]ComponentsLinksAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties             map[string]interface{}           `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsLinks ComponentsLinks
@@ -2811,6 +2904,7 @@ func (i *ComponentsLinks) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsLinksAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2819,7 +2913,7 @@ func (i *ComponentsLinks) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsLinks) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsLinks(i), i.MapOfComponentsLinksAZAZ09Values)
+	return marshalUnion(marshalComponentsLinks(i), i.MapOfComponentsLinksAZAZ09Values, i.AdditionalProperties)
 }
 
 // ComponentsCallbacksAZAZ09 structure is generated from "#/definitions/Components->callbacks->^[a-zA-Z0-9\.\-_]+$".
@@ -2855,6 +2949,7 @@ func (i ComponentsCallbacksAZAZ09) MarshalJSON() ([]byte, error) {
 // ComponentsCallbacks structure is generated from "#/definitions/Components->callbacks".
 type ComponentsCallbacks struct {
 	MapOfComponentsCallbacksAZAZ09Values map[string]ComponentsCallbacksAZAZ09 `json:"-"` // Key must match pattern: ^[a-zA-Z0-9\.\-_]+$
+	AdditionalProperties                 map[string]interface{}               `json:"-"` // All unmatched properties
 }
 
 type marshalComponentsCallbacks ComponentsCallbacks
@@ -2866,6 +2961,7 @@ func (i *ComponentsCallbacks) UnmarshalJSON(data []byte) error {
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regexAZAZ09: &i.MapOfComponentsCallbacksAZAZ09Values, // ^[a-zA-Z0-9\.\-_]+$
 		},
+		additionalProperties: &i.AdditionalProperties,
 		jsonData: data,
 	}.unmarshal()
 
@@ -2874,7 +2970,7 @@ func (i *ComponentsCallbacks) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ComponentsCallbacks) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalComponentsCallbacks(i), i.MapOfComponentsCallbacksAZAZ09Values)
+	return marshalUnion(marshalComponentsCallbacks(i), i.MapOfComponentsCallbacksAZAZ09Values, i.AdditionalProperties)
 }
 
 // SchemaType is an enum type.

--- a/tests/resources/go/swagger/entities.go
+++ b/tests/resources/go/swagger/entities.go
@@ -29,7 +29,7 @@ type SwaggerSchema struct {
 	SecurityDefinitions map[string]SecurityDefinitionsAdditionalProperties `json:"securityDefinitions,omitempty"`
 	Tags                []Tag                                              `json:"tags,omitempty"`
 	ExternalDocs        *ExternalDocs                                      `json:"externalDocs,omitempty"`        // information about external documentation
-	MapOfAnythingValues map[string]interface{}                             `json:"-"`                             // Key must match pattern: ^x-
+	MapOfAnything       map[string]interface{}                             `json:"-"`                             // Key must match pattern: ^x-
 }
 
 type marshalSwaggerSchema SwaggerSchema
@@ -57,9 +57,10 @@ func (i *SwaggerSchema) UnmarshalJSON(data []byte) error {
 			"securityDefinitions",
 			"tags",
 			"externalDocs",
+			"swagger",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -80,20 +81,20 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i SwaggerSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constSwaggerSchema, marshalSwaggerSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constSwaggerSchema, marshalSwaggerSchema(i), i.MapOfAnything)
 }
 
 // Info structure is generated from "#/definitions/info".
 //
 // General information about the API.
 type Info struct {
-	Title               string                 `json:"title,omitempty"`          // A unique and precise title of the API.
-	Version             string                 `json:"version,omitempty"`        // A semantic version number of the API.
-	Description         string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed.
-	TermsOfService      string                 `json:"termsOfService,omitempty"` // The terms of service for the API.
-	Contact             *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
-	License             *License               `json:"license,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
+	Title          string                 `json:"title,omitempty"`          // A unique and precise title of the API.
+	Version        string                 `json:"version,omitempty"`        // A semantic version number of the API.
+	Description    string                 `json:"description,omitempty"`    // A longer description of the API. Should be different from the title.  GitHub Flavored Markdown is allowed.
+	TermsOfService string                 `json:"termsOfService,omitempty"` // The terms of service for the API.
+	Contact        *Contact               `json:"contact,omitempty"`        // Contact information for the owners of the API.
+	License        *License               `json:"license,omitempty"`
+	MapOfAnything  map[string]interface{} `json:"-"`                        // Key must match pattern: ^x-
 }
 
 type marshalInfo Info
@@ -113,7 +114,7 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 			"license",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -126,17 +127,17 @@ func (i *Info) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Info) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalInfo(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalInfo(i), i.MapOfAnything)
 }
 
 // Contact structure is generated from "#/definitions/contact".
 //
 // Contact information for the owners of the API.
 type Contact struct {
-	Name                string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
-	URL                 string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
-	Email               string                 `json:"email,omitempty"` // The email address of the contact person/organization.
-	MapOfAnythingValues map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`  // The identifying name of the contact person/organization.
+	URL           string                 `json:"url,omitempty"`   // The URL pointing to the contact information.
+	Email         string                 `json:"email,omitempty"` // The email address of the contact person/organization.
+	MapOfAnything map[string]interface{} `json:"-"`               // Key must match pattern: ^x-
 }
 
 type marshalContact Contact
@@ -153,7 +154,7 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 			"email",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -166,14 +167,14 @@ func (i *Contact) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Contact) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalContact(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalContact(i), i.MapOfAnything)
 }
 
 // License structure is generated from "#/definitions/license".
 type License struct {
-	Name                string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
-	URL                 string                 `json:"url,omitempty"`  // The URL pointing to the license.
-	MapOfAnythingValues map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"` // The name of the license type. It's encouraged to use an OSI compatible license.
+	URL           string                 `json:"url,omitempty"`  // The URL pointing to the license.
+	MapOfAnything map[string]interface{} `json:"-"`              // Key must match pattern: ^x-
 }
 
 type marshalLicense License
@@ -189,7 +190,7 @@ func (i *License) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -202,14 +203,14 @@ func (i *License) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i License) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalLicense(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalLicense(i), i.MapOfAnything)
 }
 
 // Paths structure is generated from "#/definitions/paths".
 //
 // Relative paths to the individual endpoints. They must be relative to the 'basePath'.
 type Paths struct {
-	MapOfAnythingValues map[string]interface{} `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything       map[string]interface{} `json:"-"` // Key must match pattern: ^x-
 	MapOfPathItemValues map[string]PathItem    `json:"-"` // Key must match pattern: ^/
 }
 
@@ -220,7 +221,7 @@ func (i *Paths) UnmarshalJSON(data []byte) error {
 
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 			regex: &i.MapOfPathItemValues, // ^/
 		},
 		jsonData: data,
@@ -231,21 +232,21 @@ func (i *Paths) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Paths) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPaths(i), i.MapOfAnythingValues, i.MapOfPathItemValues)
+	return marshalUnion(marshalPaths(i), i.MapOfAnything, i.MapOfPathItemValues)
 }
 
 // PathItem structure is generated from "#/definitions/pathItem".
 type PathItem struct {
-	Ref                 string                 `json:"$ref,omitempty"`
-	Get                 *Operation             `json:"get,omitempty"`
-	Put                 *Operation             `json:"put,omitempty"`
-	Post                *Operation             `json:"post,omitempty"`
-	Delete              *Operation             `json:"delete,omitempty"`
-	Options             *Operation             `json:"options,omitempty"`
-	Head                *Operation             `json:"head,omitempty"`
-	Patch               *Operation             `json:"patch,omitempty"`
-	Parameters          []ParametersListItems  `json:"parameters,omitempty"` // The parameters needed to send a valid API call.
-	MapOfAnythingValues map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
+	Ref           string                 `json:"$ref,omitempty"`
+	Get           *Operation             `json:"get,omitempty"`
+	Put           *Operation             `json:"put,omitempty"`
+	Post          *Operation             `json:"post,omitempty"`
+	Delete        *Operation             `json:"delete,omitempty"`
+	Options       *Operation             `json:"options,omitempty"`
+	Head          *Operation             `json:"head,omitempty"`
+	Patch         *Operation             `json:"patch,omitempty"`
+	Parameters    []ParametersListItems  `json:"parameters,omitempty"` // The parameters needed to send a valid API call.
+	MapOfAnything map[string]interface{} `json:"-"`                    // Key must match pattern: ^x-
 }
 
 type marshalPathItem PathItem
@@ -268,7 +269,7 @@ func (i *PathItem) UnmarshalJSON(data []byte) error {
 			"parameters",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -281,24 +282,24 @@ func (i *PathItem) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i PathItem) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPathItem(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalPathItem(i), i.MapOfAnything)
 }
 
 // Operation structure is generated from "#/definitions/operation".
 type Operation struct {
-	Tags                []string               `json:"tags,omitempty"`
-	Summary             string                 `json:"summary,omitempty"`      // A brief summary of the operation.
-	Description         string                 `json:"description,omitempty"`  // A longer description of the operation, GitHub Flavored Markdown is allowed.
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	ID                  string                 `json:"operationId,omitempty"`  // A unique identifier of the operation.
-	Produces            []string               `json:"produces,omitempty"`     // A list of MIME types the API can produce.
-	Consumes            []string               `json:"consumes,omitempty"`     // A list of MIME types the API can consume.
-	Parameters          []ParametersListItems  `json:"parameters,omitempty"`   // The parameters needed to send a valid API call.
-	Responses           *Responses             `json:"responses,omitempty"`    // Response objects names can either be any valid HTTP status code or 'default'.
-	Schemes             []SchemesListItems     `json:"schemes,omitempty"`      // The transfer protocol of the API.
-	Deprecated          bool                   `json:"deprecated,omitempty"`
-	Security            []map[string][]string  `json:"security,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Tags          []string               `json:"tags,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`      // A brief summary of the operation.
+	Description   string                 `json:"description,omitempty"`  // A longer description of the operation, GitHub Flavored Markdown is allowed.
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	ID            string                 `json:"operationId,omitempty"`  // A unique identifier of the operation.
+	Produces      []string               `json:"produces,omitempty"`     // A list of MIME types the API can produce.
+	Consumes      []string               `json:"consumes,omitempty"`     // A list of MIME types the API can consume.
+	Parameters    []ParametersListItems  `json:"parameters,omitempty"`   // The parameters needed to send a valid API call.
+	Responses     *Responses             `json:"responses,omitempty"`    // Response objects names can either be any valid HTTP status code or 'default'.
+	Schemes       []SchemesListItems     `json:"schemes,omitempty"`      // The transfer protocol of the API.
+	Deprecated    bool                   `json:"deprecated,omitempty"`
+	Security      []map[string][]string  `json:"security,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalOperation Operation
@@ -324,7 +325,7 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 			"security",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -337,16 +338,16 @@ func (i *Operation) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Operation) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalOperation(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalOperation(i), i.MapOfAnything)
 }
 
 // ExternalDocs structure is generated from "#/definitions/externalDocs".
 //
 // information about external documentation.
 type ExternalDocs struct {
-	Description         string                 `json:"description,omitempty"`
-	URL                 string                 `json:"url,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	URL           string                 `json:"url,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalExternalDocs ExternalDocs
@@ -362,7 +363,7 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 			"url",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -375,16 +376,16 @@ func (i *ExternalDocs) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i ExternalDocs) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalExternalDocs(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalExternalDocs(i), i.MapOfAnything)
 }
 
 // BodyParameter structure is generated from "#/definitions/bodyParameter".
 type BodyParameter struct {
-	Description         string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                 `json:"name,omitempty"`        // The name of the parameter.
-	Required            bool                   `json:"required,omitempty"`    // Determines whether or not this parameter is required or optional.
-	Schema              *Schema                `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"` // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name          string                 `json:"name,omitempty"`        // The name of the parameter.
+	Required      bool                   `json:"required,omitempty"`    // Determines whether or not this parameter is required or optional.
+	Schema        *Schema                `json:"schema,omitempty"`      // A deterministic version of a JSON Schema object.
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalBodyParameter BodyParameter
@@ -402,9 +403,10 @@ func (i *BodyParameter) UnmarshalJSON(data []byte) error {
 			"name",
 			"required",
 			"schema",
+			"in",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -425,7 +427,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i BodyParameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constBodyParameter, marshalBodyParameter(i), i.MapOfAnythingValues)
+	return marshalUnion(constBodyParameter, marshalBodyParameter(i), i.MapOfAnything)
 }
 
 // Schema structure is generated from "#/definitions/schema".
@@ -452,7 +454,7 @@ type Schema struct {
 	MinProperties        int64                                         `json:"minProperties,omitempty"`
 	Required             []string                                      `json:"required,omitempty"`
 	Enum                 []interface{}                                 `json:"enum,omitempty"`
-	MapOfAnythingValues  map[string]interface{}                        `json:"-"`                              // Key must match pattern: ^x-
+	MapOfAnything        map[string]interface{}                        `json:"-"`                              // Key must match pattern: ^x-
 	AdditionalProperties *SchemaAdditionalProperties                   `json:"additionalProperties,omitempty"`
 	Type                 *HTTPJSONSchemaOrgDraft04SchemaPropertiesType `json:"type,omitempty"`
 	Items                *SchemaItems                                  `json:"items,omitempty"`
@@ -506,7 +508,7 @@ func (i *Schema) UnmarshalJSON(data []byte) error {
 			"example",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -519,7 +521,7 @@ func (i *Schema) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Schema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalSchema(i), i.MapOfAnything)
 }
 
 // SchemaAdditionalProperties structure is generated from "#/definitions/schema->additionalProperties".
@@ -554,15 +556,15 @@ func (i SchemaAdditionalProperties) MarshalJSON() ([]byte, error) {
 
 // HTTPJSONSchemaOrgDraft04SchemaPropertiesType structure is generated from "http://json-schema.org/draft-04/schema#/properties/type".
 type HTTPJSONSchemaOrgDraft04SchemaPropertiesType struct {
-	SimpleTypes *SimpleTypes  `json:"-"`
-	AnyOf1      []SimpleTypes `json:"-"`
+	SimpleTypes              *SimpleTypes  `json:"-"`
+	SliceOfSimpleTypesValues []SimpleTypes `json:"-"`
 }
 
 type marshalHTTPJSONSchemaOrgDraft04SchemaPropertiesType HTTPJSONSchemaOrgDraft04SchemaPropertiesType
 
 // UnmarshalJSON decodes JSON.
 func (i *HTTPJSONSchemaOrgDraft04SchemaPropertiesType) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.SimpleTypes, &i.AnyOf1}
+	mayUnmarshal := []interface{}{&i.SimpleTypes, &i.SliceOfSimpleTypesValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -571,7 +573,7 @@ func (i *HTTPJSONSchemaOrgDraft04SchemaPropertiesType) UnmarshalJSON(data []byte
 		i.SimpleTypes = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.AnyOf1 = nil
+		i.SliceOfSimpleTypesValues = nil
 	}
 
 	return err
@@ -579,20 +581,20 @@ func (i *HTTPJSONSchemaOrgDraft04SchemaPropertiesType) UnmarshalJSON(data []byte
 
 // MarshalJSON encodes JSON.
 func (i HTTPJSONSchemaOrgDraft04SchemaPropertiesType) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalHTTPJSONSchemaOrgDraft04SchemaPropertiesType(i), i.SimpleTypes, i.AnyOf1)
+	return marshalUnion(marshalHTTPJSONSchemaOrgDraft04SchemaPropertiesType(i), i.SimpleTypes, i.SliceOfSimpleTypesValues)
 }
 
 // SchemaItems structure is generated from "#/definitions/schema->items".
 type SchemaItems struct {
-	Schema *Schema  `json:"-"`
-	AnyOf1 []Schema `json:"-"`
+	Schema              *Schema  `json:"-"`
+	SliceOfSchemaValues []Schema `json:"-"`
 }
 
 type marshalSchemaItems SchemaItems
 
 // UnmarshalJSON decodes JSON.
 func (i *SchemaItems) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Schema, &i.AnyOf1}
+	mayUnmarshal := []interface{}{&i.Schema, &i.SliceOfSchemaValues}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -601,7 +603,7 @@ func (i *SchemaItems) UnmarshalJSON(data []byte) error {
 		i.Schema = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.AnyOf1 = nil
+		i.SliceOfSchemaValues = nil
 	}
 
 	return err
@@ -609,17 +611,17 @@ func (i *SchemaItems) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i SchemaItems) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalSchemaItems(i), i.Schema, i.AnyOf1)
+	return marshalUnion(marshalSchemaItems(i), i.Schema, i.SliceOfSchemaValues)
 }
 
 // XML structure is generated from "#/definitions/xml".
 type XML struct {
-	Name                string                 `json:"name,omitempty"`
-	Namespace           string                 `json:"namespace,omitempty"`
-	Prefix              string                 `json:"prefix,omitempty"`
-	Attribute           bool                   `json:"attribute,omitempty"`
-	Wrapped             bool                   `json:"wrapped,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                   // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Namespace     string                 `json:"namespace,omitempty"`
+	Prefix        string                 `json:"prefix,omitempty"`
+	Attribute     bool                   `json:"attribute,omitempty"`
+	Wrapped       bool                   `json:"wrapped,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                   // Key must match pattern: ^x-
 }
 
 type marshalXML XML
@@ -638,7 +640,7 @@ func (i *XML) UnmarshalJSON(data []byte) error {
 			"wrapped",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -651,32 +653,32 @@ func (i *XML) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i XML) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalXML(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalXML(i), i.MapOfAnything)
 }
 
 // HeaderParameterSubSchema structure is generated from "#/definitions/headerParameterSubSchema".
 type HeaderParameterSubSchema struct {
-	Required            bool                         `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
-	Description         string                       `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                       `json:"name,omitempty"`             // The name of the parameter.
-	Type                HeaderParameterSubSchemaType `json:"type,omitempty"`
-	Format              string                       `json:"format,omitempty"`
-	Items               *PrimitivesItems             `json:"items,omitempty"`
-	CollectionFormat    CollectionFormat             `json:"collectionFormat,omitempty"`
-	Default             interface{}                  `json:"default,omitempty"`
-	Maximum             float64                      `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                         `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                      `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                         `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                        `json:"maxLength,omitempty"`
-	MinLength           int64                        `json:"minLength,omitempty"`
-	Pattern             string                       `json:"pattern,omitempty"`
-	MaxItems            int64                        `json:"maxItems,omitempty"`
-	MinItems            int64                        `json:"minItems,omitempty"`
-	UniqueItems         bool                         `json:"uniqueItems,omitempty"`
-	Enum                []interface{}                `json:"enum,omitempty"`
-	MultipleOf          float64                      `json:"multipleOf,omitempty"`
-	MapOfAnythingValues map[string]interface{}       `json:"-"`                          // Key must match pattern: ^x-
+	Required         bool                         `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
+	Description      string                       `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name             string                       `json:"name,omitempty"`             // The name of the parameter.
+	Type             HeaderParameterSubSchemaType `json:"type,omitempty"`
+	Format           string                       `json:"format,omitempty"`
+	Items            *PrimitivesItems             `json:"items,omitempty"`
+	CollectionFormat CollectionFormat             `json:"collectionFormat,omitempty"`
+	Default          interface{}                  `json:"default,omitempty"`
+	Maximum          float64                      `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                         `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                      `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                         `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                        `json:"maxLength,omitempty"`
+	MinLength        int64                        `json:"minLength,omitempty"`
+	Pattern          string                       `json:"pattern,omitempty"`
+	MaxItems         int64                        `json:"maxItems,omitempty"`
+	MinItems         int64                        `json:"minItems,omitempty"`
+	UniqueItems      bool                         `json:"uniqueItems,omitempty"`
+	Enum             []interface{}                `json:"enum,omitempty"`
+	MultipleOf       float64                      `json:"multipleOf,omitempty"`
+	MapOfAnything    map[string]interface{}       `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalHeaderParameterSubSchema HeaderParameterSubSchema
@@ -710,9 +712,10 @@ func (i *HeaderParameterSubSchema) UnmarshalJSON(data []byte) error {
 			"uniqueItems",
 			"enum",
 			"multipleOf",
+			"in",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -733,29 +736,29 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i HeaderParameterSubSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constHeaderParameterSubSchema, marshalHeaderParameterSubSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constHeaderParameterSubSchema, marshalHeaderParameterSubSchema(i), i.MapOfAnything)
 }
 
 // PrimitivesItems structure is generated from "#/definitions/primitivesItems".
 type PrimitivesItems struct {
-	Type                PrimitivesItemsType    `json:"type,omitempty"`
-	Format              string                 `json:"format,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
-	Items               *PrimitivesItems       `json:"items,omitempty"`
-	CollectionFormat    CollectionFormat       `json:"collectionFormat,omitempty"`
-	Default             interface{}            `json:"default,omitempty"`
-	Maximum             float64                `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                   `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                   `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                  `json:"maxLength,omitempty"`
-	MinLength           int64                  `json:"minLength,omitempty"`
-	Pattern             string                 `json:"pattern,omitempty"`
-	MaxItems            int64                  `json:"maxItems,omitempty"`
-	MinItems            int64                  `json:"minItems,omitempty"`
-	UniqueItems         bool                   `json:"uniqueItems,omitempty"`
-	Enum                []interface{}          `json:"enum,omitempty"`
-	MultipleOf          float64                `json:"multipleOf,omitempty"`
+	Type             PrimitivesItemsType    `json:"type,omitempty"`
+	Format           string                 `json:"format,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	Items            *PrimitivesItems       `json:"items,omitempty"`
+	CollectionFormat CollectionFormat       `json:"collectionFormat,omitempty"`
+	Default          interface{}            `json:"default,omitempty"`
+	Maximum          float64                `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                   `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                   `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                  `json:"maxLength,omitempty"`
+	MinLength        int64                  `json:"minLength,omitempty"`
+	Pattern          string                 `json:"pattern,omitempty"`
+	MaxItems         int64                  `json:"maxItems,omitempty"`
+	MinItems         int64                  `json:"minItems,omitempty"`
+	UniqueItems      bool                   `json:"uniqueItems,omitempty"`
+	Enum             []interface{}          `json:"enum,omitempty"`
+	MultipleOf       float64                `json:"multipleOf,omitempty"`
 }
 
 type marshalPrimitivesItems PrimitivesItems
@@ -786,7 +789,7 @@ func (i *PrimitivesItems) UnmarshalJSON(data []byte) error {
 			"multipleOf",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -799,33 +802,33 @@ func (i *PrimitivesItems) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i PrimitivesItems) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalPrimitivesItems(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalPrimitivesItems(i), i.MapOfAnything)
 }
 
 // FormDataParameterSubSchema structure is generated from "#/definitions/formDataParameterSubSchema".
 type FormDataParameterSubSchema struct {
-	Required            bool                           `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
-	Description         string                         `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                         `json:"name,omitempty"`             // The name of the parameter.
-	AllowEmptyValue     bool                           `json:"allowEmptyValue,omitempty"`  // allows sending a parameter by name only or with an empty value.
-	Type                FormDataParameterSubSchemaType `json:"type,omitempty"`
-	Format              string                         `json:"format,omitempty"`
-	Items               *PrimitivesItems               `json:"items,omitempty"`
-	CollectionFormat    CollectionFormatWithMulti      `json:"collectionFormat,omitempty"`
-	Default             interface{}                    `json:"default,omitempty"`
-	Maximum             float64                        `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                           `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                        `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                           `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                          `json:"maxLength,omitempty"`
-	MinLength           int64                          `json:"minLength,omitempty"`
-	Pattern             string                         `json:"pattern,omitempty"`
-	MaxItems            int64                          `json:"maxItems,omitempty"`
-	MinItems            int64                          `json:"minItems,omitempty"`
-	UniqueItems         bool                           `json:"uniqueItems,omitempty"`
-	Enum                []interface{}                  `json:"enum,omitempty"`
-	MultipleOf          float64                        `json:"multipleOf,omitempty"`
-	MapOfAnythingValues map[string]interface{}         `json:"-"`                          // Key must match pattern: ^x-
+	Required         bool                           `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
+	Description      string                         `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name             string                         `json:"name,omitempty"`             // The name of the parameter.
+	AllowEmptyValue  bool                           `json:"allowEmptyValue,omitempty"`  // allows sending a parameter by name only or with an empty value.
+	Type             FormDataParameterSubSchemaType `json:"type,omitempty"`
+	Format           string                         `json:"format,omitempty"`
+	Items            *PrimitivesItems               `json:"items,omitempty"`
+	CollectionFormat CollectionFormatWithMulti      `json:"collectionFormat,omitempty"`
+	Default          interface{}                    `json:"default,omitempty"`
+	Maximum          float64                        `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                           `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                        `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                           `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                          `json:"maxLength,omitempty"`
+	MinLength        int64                          `json:"minLength,omitempty"`
+	Pattern          string                         `json:"pattern,omitempty"`
+	MaxItems         int64                          `json:"maxItems,omitempty"`
+	MinItems         int64                          `json:"minItems,omitempty"`
+	UniqueItems      bool                           `json:"uniqueItems,omitempty"`
+	Enum             []interface{}                  `json:"enum,omitempty"`
+	MultipleOf       float64                        `json:"multipleOf,omitempty"`
+	MapOfAnything    map[string]interface{}         `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalFormDataParameterSubSchema FormDataParameterSubSchema
@@ -860,9 +863,10 @@ func (i *FormDataParameterSubSchema) UnmarshalJSON(data []byte) error {
 			"uniqueItems",
 			"enum",
 			"multipleOf",
+			"in",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -883,33 +887,33 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i FormDataParameterSubSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constFormDataParameterSubSchema, marshalFormDataParameterSubSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constFormDataParameterSubSchema, marshalFormDataParameterSubSchema(i), i.MapOfAnything)
 }
 
 // QueryParameterSubSchema structure is generated from "#/definitions/queryParameterSubSchema".
 type QueryParameterSubSchema struct {
-	Required            bool                        `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
-	Description         string                      `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                      `json:"name,omitempty"`             // The name of the parameter.
-	AllowEmptyValue     bool                        `json:"allowEmptyValue,omitempty"`  // allows sending a parameter by name only or with an empty value.
-	Type                QueryParameterSubSchemaType `json:"type,omitempty"`
-	Format              string                      `json:"format,omitempty"`
-	Items               *PrimitivesItems            `json:"items,omitempty"`
-	CollectionFormat    CollectionFormatWithMulti   `json:"collectionFormat,omitempty"`
-	Default             interface{}                 `json:"default,omitempty"`
-	Maximum             float64                     `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                        `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                     `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                        `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                       `json:"maxLength,omitempty"`
-	MinLength           int64                       `json:"minLength,omitempty"`
-	Pattern             string                      `json:"pattern,omitempty"`
-	MaxItems            int64                       `json:"maxItems,omitempty"`
-	MinItems            int64                       `json:"minItems,omitempty"`
-	UniqueItems         bool                        `json:"uniqueItems,omitempty"`
-	Enum                []interface{}               `json:"enum,omitempty"`
-	MultipleOf          float64                     `json:"multipleOf,omitempty"`
-	MapOfAnythingValues map[string]interface{}      `json:"-"`                          // Key must match pattern: ^x-
+	Required         bool                        `json:"required,omitempty"`         // Determines whether or not this parameter is required or optional.
+	Description      string                      `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name             string                      `json:"name,omitempty"`             // The name of the parameter.
+	AllowEmptyValue  bool                        `json:"allowEmptyValue,omitempty"`  // allows sending a parameter by name only or with an empty value.
+	Type             QueryParameterSubSchemaType `json:"type,omitempty"`
+	Format           string                      `json:"format,omitempty"`
+	Items            *PrimitivesItems            `json:"items,omitempty"`
+	CollectionFormat CollectionFormatWithMulti   `json:"collectionFormat,omitempty"`
+	Default          interface{}                 `json:"default,omitempty"`
+	Maximum          float64                     `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                        `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                     `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                        `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                       `json:"maxLength,omitempty"`
+	MinLength        int64                       `json:"minLength,omitempty"`
+	Pattern          string                      `json:"pattern,omitempty"`
+	MaxItems         int64                       `json:"maxItems,omitempty"`
+	MinItems         int64                       `json:"minItems,omitempty"`
+	UniqueItems      bool                        `json:"uniqueItems,omitempty"`
+	Enum             []interface{}               `json:"enum,omitempty"`
+	MultipleOf       float64                     `json:"multipleOf,omitempty"`
+	MapOfAnything    map[string]interface{}      `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalQueryParameterSubSchema QueryParameterSubSchema
@@ -944,9 +948,10 @@ func (i *QueryParameterSubSchema) UnmarshalJSON(data []byte) error {
 			"uniqueItems",
 			"enum",
 			"multipleOf",
+			"in",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -967,31 +972,31 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i QueryParameterSubSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constQueryParameterSubSchema, marshalQueryParameterSubSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constQueryParameterSubSchema, marshalQueryParameterSubSchema(i), i.MapOfAnything)
 }
 
 // PathParameterSubSchema structure is generated from "#/definitions/pathParameterSubSchema".
 type PathParameterSubSchema struct {
-	Description         string                     `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
-	Name                string                     `json:"name,omitempty"`             // The name of the parameter.
-	Type                PathParameterSubSchemaType `json:"type,omitempty"`
-	Format              string                     `json:"format,omitempty"`
-	Items               *PrimitivesItems           `json:"items,omitempty"`
-	CollectionFormat    CollectionFormat           `json:"collectionFormat,omitempty"`
-	Default             interface{}                `json:"default,omitempty"`
-	Maximum             float64                    `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                       `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                    `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                       `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                      `json:"maxLength,omitempty"`
-	MinLength           int64                      `json:"minLength,omitempty"`
-	Pattern             string                     `json:"pattern,omitempty"`
-	MaxItems            int64                      `json:"maxItems,omitempty"`
-	MinItems            int64                      `json:"minItems,omitempty"`
-	UniqueItems         bool                       `json:"uniqueItems,omitempty"`
-	Enum                []interface{}              `json:"enum,omitempty"`
-	MultipleOf          float64                    `json:"multipleOf,omitempty"`
-	MapOfAnythingValues map[string]interface{}     `json:"-"`                          // Key must match pattern: ^x-
+	Description      string                     `json:"description,omitempty"`      // A brief description of the parameter. This could contain examples of use.  GitHub Flavored Markdown is allowed.
+	Name             string                     `json:"name,omitempty"`             // The name of the parameter.
+	Type             PathParameterSubSchemaType `json:"type,omitempty"`
+	Format           string                     `json:"format,omitempty"`
+	Items            *PrimitivesItems           `json:"items,omitempty"`
+	CollectionFormat CollectionFormat           `json:"collectionFormat,omitempty"`
+	Default          interface{}                `json:"default,omitempty"`
+	Maximum          float64                    `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                       `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                    `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                       `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                      `json:"maxLength,omitempty"`
+	MinLength        int64                      `json:"minLength,omitempty"`
+	Pattern          string                     `json:"pattern,omitempty"`
+	MaxItems         int64                      `json:"maxItems,omitempty"`
+	MinItems         int64                      `json:"minItems,omitempty"`
+	UniqueItems      bool                       `json:"uniqueItems,omitempty"`
+	Enum             []interface{}              `json:"enum,omitempty"`
+	MultipleOf       float64                    `json:"multipleOf,omitempty"`
+	MapOfAnything    map[string]interface{}     `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalPathParameterSubSchema PathParameterSubSchema
@@ -1024,9 +1029,11 @@ func (i *PathParameterSubSchema) UnmarshalJSON(data []byte) error {
 			"uniqueItems",
 			"enum",
 			"multipleOf",
+			"required",
+			"in",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1050,7 +1057,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i PathParameterSubSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constPathParameterSubSchema, marshalPathParameterSubSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constPathParameterSubSchema, marshalPathParameterSubSchema(i), i.MapOfAnything)
 }
 
 // NonBodyParameter structure is generated from "#/definitions/nonBodyParameter".
@@ -1158,11 +1165,11 @@ func (i ParametersListItems) MarshalJSON() ([]byte, error) {
 
 // Response structure is generated from "#/definitions/response".
 type Response struct {
-	Description         string                 `json:"description,omitempty"`
-	Schema              *ResponseSchema        `json:"schema,omitempty"`
-	Headers             map[string]Header      `json:"headers,omitempty"`
-	Examples            map[string]interface{} `json:"examples,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	Schema        *ResponseSchema        `json:"schema,omitempty"`
+	Headers       map[string]Header      `json:"headers,omitempty"`
+	Examples      map[string]interface{} `json:"examples,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalResponse Response
@@ -1180,7 +1187,7 @@ func (i *Response) UnmarshalJSON(data []byte) error {
 			"examples",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1193,22 +1200,22 @@ func (i *Response) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Response) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalResponse(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalResponse(i), i.MapOfAnything)
 }
 
 // FileSchema structure is generated from "#/definitions/fileSchema".
 //
 // A deterministic version of a JSON Schema object.
 type FileSchema struct {
-	Format              string                 `json:"format,omitempty"`
-	Title               string                 `json:"title,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	Default             interface{}            `json:"default,omitempty"`
-	Required            []string               `json:"required,omitempty"`
-	ReadOnly            bool                   `json:"readOnly,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	Example             interface{}            `json:"example,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Format        string                 `json:"format,omitempty"`
+	Title         string                 `json:"title,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	Default       interface{}            `json:"default,omitempty"`
+	Required      []string               `json:"required,omitempty"`
+	ReadOnly      bool                   `json:"readOnly,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	Example       interface{}            `json:"example,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalFileSchema FileSchema
@@ -1230,9 +1237,10 @@ func (i *FileSchema) UnmarshalJSON(data []byte) error {
 			"readOnly",
 			"externalDocs",
 			"example",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1253,7 +1261,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i FileSchema) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constFileSchema, marshalFileSchema(i), i.MapOfAnythingValues)
+	return marshalUnion(constFileSchema, marshalFileSchema(i), i.MapOfAnything)
 }
 
 // ResponseSchema structure is generated from "#/definitions/response->schema".
@@ -1288,25 +1296,25 @@ func (i ResponseSchema) MarshalJSON() ([]byte, error) {
 
 // Header structure is generated from "#/definitions/header".
 type Header struct {
-	Type                HeaderType             `json:"type,omitempty"`
-	Format              string                 `json:"format,omitempty"`
-	Items               *PrimitivesItems       `json:"items,omitempty"`
-	CollectionFormat    CollectionFormat       `json:"collectionFormat,omitempty"`
-	Default             interface{}            `json:"default,omitempty"`
-	Maximum             float64                `json:"maximum,omitempty"`
-	ExclusiveMaximum    bool                   `json:"exclusiveMaximum,omitempty"`
-	Minimum             float64                `json:"minimum,omitempty"`
-	ExclusiveMinimum    bool                   `json:"exclusiveMinimum,omitempty"`
-	MaxLength           int64                  `json:"maxLength,omitempty"`
-	MinLength           int64                  `json:"minLength,omitempty"`
-	Pattern             string                 `json:"pattern,omitempty"`
-	MaxItems            int64                  `json:"maxItems,omitempty"`
-	MinItems            int64                  `json:"minItems,omitempty"`
-	UniqueItems         bool                   `json:"uniqueItems,omitempty"`
-	Enum                []interface{}          `json:"enum,omitempty"`
-	MultipleOf          float64                `json:"multipleOf,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	Type             HeaderType             `json:"type,omitempty"`
+	Format           string                 `json:"format,omitempty"`
+	Items            *PrimitivesItems       `json:"items,omitempty"`
+	CollectionFormat CollectionFormat       `json:"collectionFormat,omitempty"`
+	Default          interface{}            `json:"default,omitempty"`
+	Maximum          float64                `json:"maximum,omitempty"`
+	ExclusiveMaximum bool                   `json:"exclusiveMaximum,omitempty"`
+	Minimum          float64                `json:"minimum,omitempty"`
+	ExclusiveMinimum bool                   `json:"exclusiveMinimum,omitempty"`
+	MaxLength        int64                  `json:"maxLength,omitempty"`
+	MinLength        int64                  `json:"minLength,omitempty"`
+	Pattern          string                 `json:"pattern,omitempty"`
+	MaxItems         int64                  `json:"maxItems,omitempty"`
+	MinItems         int64                  `json:"minItems,omitempty"`
+	UniqueItems      bool                   `json:"uniqueItems,omitempty"`
+	Enum             []interface{}          `json:"enum,omitempty"`
+	MultipleOf       float64                `json:"multipleOf,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalHeader Header
@@ -1338,7 +1346,7 @@ func (i *Header) UnmarshalJSON(data []byte) error {
 			"description",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1351,7 +1359,7 @@ func (i *Header) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Header) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalHeader(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalHeader(i), i.MapOfAnything)
 }
 
 // ResponseValue structure is generated from "#/definitions/responseValue".
@@ -1389,7 +1397,7 @@ func (i ResponseValue) MarshalJSON() ([]byte, error) {
 // Response objects names can either be any valid HTTP status code or 'default'.
 type Responses struct {
 	MapOfResponseValueValues map[string]ResponseValue `json:"-"` // Key must match pattern: ^([0-9]{3})$|^(default)$
-	MapOfAnythingValues      map[string]interface{}   `json:"-"` // Key must match pattern: ^x-
+	MapOfAnything            map[string]interface{}   `json:"-"` // Key must match pattern: ^x-
 }
 
 type marshalResponses Responses
@@ -1400,7 +1408,7 @@ func (i *Responses) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		patternProperties: map[*regexp.Regexp]interface{}{
 			regex093Default: &i.MapOfResponseValueValues, // ^([0-9]{3})$|^(default)$
-			regexX: &i.MapOfAnythingValues, // ^x-
+			regexX: &i.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1410,13 +1418,13 @@ func (i *Responses) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Responses) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalResponses(i), i.MapOfResponseValueValues, i.MapOfAnythingValues)
+	return marshalUnion(marshalResponses(i), i.MapOfResponseValueValues, i.MapOfAnything)
 }
 
 // BasicAuthenticationSecurity structure is generated from "#/definitions/basicAuthenticationSecurity".
 type BasicAuthenticationSecurity struct {
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalBasicAuthenticationSecurity BasicAuthenticationSecurity
@@ -1431,9 +1439,10 @@ func (i *BasicAuthenticationSecurity) UnmarshalJSON(data []byte) error {
 		mayUnmarshal: mayUnmarshal,
 		ignoreKeys: []string{
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1454,15 +1463,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i BasicAuthenticationSecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constBasicAuthenticationSecurity, marshalBasicAuthenticationSecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constBasicAuthenticationSecurity, marshalBasicAuthenticationSecurity(i), i.MapOfAnything)
 }
 
 // APIKeySecurity structure is generated from "#/definitions/apiKeySecurity".
 type APIKeySecurity struct {
-	Name                string                 `json:"name,omitempty"`
-	In                  APIKeySecurityIn       `json:"in,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	In            APIKeySecurityIn       `json:"in,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalAPIKeySecurity APIKeySecurity
@@ -1479,9 +1488,10 @@ func (i *APIKeySecurity) UnmarshalJSON(data []byte) error {
 			"name",
 			"in",
 			"description",
+			"type",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1502,15 +1512,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i APIKeySecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constAPIKeySecurity, marshalAPIKeySecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constAPIKeySecurity, marshalAPIKeySecurity(i), i.MapOfAnything)
 }
 
 // Oauth2ImplicitSecurity structure is generated from "#/definitions/oauth2ImplicitSecurity".
 type Oauth2ImplicitSecurity struct {
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	AuthorizationURL    string                 `json:"authorizationUrl,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	Scopes           map[string]string      `json:"scopes,omitempty"`
+	AuthorizationURL string                 `json:"authorizationUrl,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalOauth2ImplicitSecurity Oauth2ImplicitSecurity
@@ -1527,9 +1537,11 @@ func (i *Oauth2ImplicitSecurity) UnmarshalJSON(data []byte) error {
 			"scopes",
 			"authorizationUrl",
 			"description",
+			"type",
+			"flow",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1553,15 +1565,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Oauth2ImplicitSecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOauth2ImplicitSecurity, marshalOauth2ImplicitSecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constOauth2ImplicitSecurity, marshalOauth2ImplicitSecurity(i), i.MapOfAnything)
 }
 
 // Oauth2PasswordSecurity structure is generated from "#/definitions/oauth2PasswordSecurity".
 type Oauth2PasswordSecurity struct {
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Scopes        map[string]string      `json:"scopes,omitempty"`
+	TokenURL      string                 `json:"tokenUrl,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalOauth2PasswordSecurity Oauth2PasswordSecurity
@@ -1578,9 +1590,11 @@ func (i *Oauth2PasswordSecurity) UnmarshalJSON(data []byte) error {
 			"scopes",
 			"tokenUrl",
 			"description",
+			"type",
+			"flow",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1604,15 +1618,15 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Oauth2PasswordSecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOauth2PasswordSecurity, marshalOauth2PasswordSecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constOauth2PasswordSecurity, marshalOauth2PasswordSecurity(i), i.MapOfAnything)
 }
 
 // Oauth2ApplicationSecurity structure is generated from "#/definitions/oauth2ApplicationSecurity".
 type Oauth2ApplicationSecurity struct {
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
+	Scopes        map[string]string      `json:"scopes,omitempty"`
+	TokenURL      string                 `json:"tokenUrl,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	MapOfAnything map[string]interface{} `json:"-"`                     // Key must match pattern: ^x-
 }
 
 type marshalOauth2ApplicationSecurity Oauth2ApplicationSecurity
@@ -1629,9 +1643,11 @@ func (i *Oauth2ApplicationSecurity) UnmarshalJSON(data []byte) error {
 			"scopes",
 			"tokenUrl",
 			"description",
+			"type",
+			"flow",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1655,16 +1671,16 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Oauth2ApplicationSecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOauth2ApplicationSecurity, marshalOauth2ApplicationSecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constOauth2ApplicationSecurity, marshalOauth2ApplicationSecurity(i), i.MapOfAnything)
 }
 
 // Oauth2AccessCodeSecurity structure is generated from "#/definitions/oauth2AccessCodeSecurity".
 type Oauth2AccessCodeSecurity struct {
-	Scopes              map[string]string      `json:"scopes,omitempty"`
-	AuthorizationURL    string                 `json:"authorizationUrl,omitempty"`
-	TokenURL            string                 `json:"tokenUrl,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	MapOfAnythingValues map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
+	Scopes           map[string]string      `json:"scopes,omitempty"`
+	AuthorizationURL string                 `json:"authorizationUrl,omitempty"`
+	TokenURL         string                 `json:"tokenUrl,omitempty"`
+	Description      string                 `json:"description,omitempty"`
+	MapOfAnything    map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
 }
 
 type marshalOauth2AccessCodeSecurity Oauth2AccessCodeSecurity
@@ -1682,9 +1698,11 @@ func (i *Oauth2AccessCodeSecurity) UnmarshalJSON(data []byte) error {
 			"authorizationUrl",
 			"tokenUrl",
 			"description",
+			"type",
+			"flow",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1708,7 +1726,7 @@ var (
 
 // MarshalJSON encodes JSON.
 func (i Oauth2AccessCodeSecurity) MarshalJSON() ([]byte, error) {
-	return marshalUnion(constOauth2AccessCodeSecurity, marshalOauth2AccessCodeSecurity(i), i.MapOfAnythingValues)
+	return marshalUnion(constOauth2AccessCodeSecurity, marshalOauth2AccessCodeSecurity(i), i.MapOfAnything)
 }
 
 // SecurityDefinitionsAdditionalProperties structure is generated from "#/definitions/securityDefinitions->additionalProperties".
@@ -1759,10 +1777,10 @@ func (i SecurityDefinitionsAdditionalProperties) MarshalJSON() ([]byte, error) {
 
 // Tag structure is generated from "#/definitions/tag".
 type Tag struct {
-	Name                string                 `json:"name,omitempty"`
-	Description         string                 `json:"description,omitempty"`
-	ExternalDocs        *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
-	MapOfAnythingValues map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
+	Name          string                 `json:"name,omitempty"`
+	Description   string                 `json:"description,omitempty"`
+	ExternalDocs  *ExternalDocs          `json:"externalDocs,omitempty"` // information about external documentation
+	MapOfAnything map[string]interface{} `json:"-"`                      // Key must match pattern: ^x-
 }
 
 type marshalTag Tag
@@ -1779,7 +1797,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 			"externalDocs",
 		},
 		patternProperties: map[*regexp.Regexp]interface{}{
-			regexX: &ii.MapOfAnythingValues, // ^x-
+			regexX: &ii.MapOfAnything, // ^x-
 		},
 		jsonData: data,
 	}.unmarshal()
@@ -1792,7 +1810,7 @@ func (i *Tag) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Tag) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalTag(i), i.MapOfAnythingValues)
+	return marshalUnion(marshalTag(i), i.MapOfAnything)
 }
 
 // SchemesListItems is an enum type.

--- a/tests/src/PHPUnit/JsonSchema/AsyncApi2Test.php
+++ b/tests/src/PHPUnit/JsonSchema/AsyncApi2Test.php
@@ -41,7 +41,5 @@ class AsyncApi2Test extends \PHPUnit_Framework_TestCase
         $expectedGen = file_get_contents(__DIR__ . '/../../../resources/go/asyncapi2/entities.go');
 
         $this->assertSame($expectedGen, $goFile->render());
-
     }
-
 }

--- a/tests/src/PHPUnit/JsonSchema/JsonSchemaGenerateTest.php
+++ b/tests/src/PHPUnit/JsonSchema/JsonSchemaGenerateTest.php
@@ -20,6 +20,7 @@ class JsonSchemaGenerateTest extends \PHPUnit_Framework_TestCase
         $builder = new GoBuilder();
         $builder->options->hideConstProperties = true;
         $builder->options->trimParentFromPropertyNames = true;
+        $builder->options->withZeroValues = true;
         $builder->structCreatedHook = new StructHookCallback(function (StructDef $structDef, $path, $schema) use ($builder) {
             if ('#' === $path) {
                 $structDef->setName('Schema');

--- a/tests/src/PHPUnit/JsonSchema/TypeBuilderTest.php
+++ b/tests/src/PHPUnit/JsonSchema/TypeBuilderTest.php
@@ -4,7 +4,7 @@ namespace Swaggest\GoCodeBuilder\Tests\PHPUnit\JsonSchema;
 
 
 use Swaggest\GoCodeBuilder\JsonSchema\GoBuilder;
-use Swaggest\JsonSchema\JsonSchema;
+use Swaggest\GoCodeBuilder\JsonSchema\TypeBuilder;
 use Swaggest\JsonSchema\Schema;
 
 class TypeBuilderTest extends \PHPUnit_Framework_TestCase
@@ -20,6 +20,7 @@ class TypeBuilderTest extends \PHPUnit_Framework_TestCase
     "definitions": {
         "header": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
                 "maximum": {"$ref": "#/definitions/maximum"}
             }
@@ -50,6 +51,120 @@ GO;
             $actualGen .= $struct->structDef;
         }
         $this->assertSame($expectedGen, $actualGen);
+    }
+
+    function testXGoTypeIgnore()
+    {
+        $builder = new GoBuilder();
+        $builder->options->ignoreXGoType = true;
+        $schema = new Schema();
+        $schema->{'x-go-type'} = 'my-package/domain/orders.Order';
+        $schema->type = Schema::STRING;
+        $tb = new TypeBuilder($schema, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('string', $type->getTypeString());
+    }
+
+
+    function testXGoTypeString()
+    {
+        $builder = new GoBuilder();
+        $schema = new Schema();
+        $schema->{'x-go-type'} = 'my-package/domain/orders.Order';
+        $tb = new TypeBuilder($schema, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('my-package/domain/orders.Order', $type->getTypeString());
+    }
+
+    function testXGoTypeGoSwaggerObject()
+    {
+        $builder = new GoBuilder();
+        $schema = new Schema();
+        $schema->{'x-go-type'} = json_decode('{
+                  "import": {
+                    "package": "my-package/domain/orders"
+                  },
+                  "type": "Order"
+                }');
+        $tb = new TypeBuilder($schema, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('my-package/domain/orders.Order', $type->getTypeString());
+    }
+
+
+    function testNullable()
+    {
+        $prop = new Schema();
+        $prop->type = [Schema::STRING, Schema::NULL];
+
+        $obj = Schema::object();
+        $obj->setProperty('nullable', $prop);
+        $obj->setProperty('regular', Schema::string());
+        $obj->additionalProperties = false;
+
+
+        $builder = new GoBuilder();
+        $tb = new TypeBuilder($prop, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('*string', $type->getTypeString());
+
+        $this->assertEquals('*Untitled1', $builder->getType($obj)->getTypeString());
+        $struct = $builder->getGeneratedStruct($obj, '#');
+
+        $this->assertEquals(<<<'GO'
+// Untitled1 structure is generated from "#".
+type Untitled1 struct {
+	Nullable *string `json:"nullable"`
+	Regular  string  `json:"regular,omitempty"`
+}
+
+
+GO
+            , $struct->structDef->render());
+
+
+        $builder = new GoBuilder();
+        $builder->options->withZeroValues = true;
+        $tb = new TypeBuilder($prop, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('*string', $type->getTypeString());
+
+        $this->assertEquals('*Untitled1', $builder->getType($obj)->getTypeString());
+        $struct = $builder->getGeneratedStruct($obj, '#');
+
+        $this->assertEquals(<<<'GO'
+// Untitled1 structure is generated from "#".
+type Untitled1 struct {
+	Nullable *string `json:"nullable"`
+	Regular  *string `json:"regular,omitempty"`
+}
+
+
+GO
+            , $struct->structDef->render());
+
+
+        $builder = new GoBuilder();
+        $builder->options->ignoreNullable = true;
+        $tb = new TypeBuilder($prop, '#', $builder);
+        $type = $tb->build();
+        $this->assertEquals('*string', $type->getTypeString());
+
+        $this->assertEquals('*Untitled1', $builder->getType($obj)->getTypeString());
+        $struct = $builder->getGeneratedStruct($obj, '#');
+
+        $this->assertEquals(<<<'GO'
+// Untitled1 structure is generated from "#".
+type Untitled1 struct {
+	Nullable *string `json:"nullable,omitempty"`
+	Regular  string  `json:"regular,omitempty"`
+}
+
+
+GO
+            , $struct->structDef->render());
+
+
     }
 
 }


### PR DESCRIPTION
### Added
- Support for `x-go-type` as object (`go-swagger` format).
- Builder option `$ignoreXGoType` to disregard `x-go-type` hints.
- Builder option `$withZeroValues` to use pointer types to avoid zero-value ambiguity.
- Builder option `$ignoreNullable` to enable `omitempty` for nullable properties.
- Automated API docs.
- Change log.

### Fixed
- Missing processing for `null` `additionalProperties`.
- Processing for nullable (`[null, <other>]`) types.

### Changed
- Multi-type schemas are decomposed into multiple structures.
- Schema title is used for structure name if available.
