### PR TITLE
Add support for `x-nullable`, improve enum namings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2019-10-09
+
+### Changed
+- Constant/enum type names are prefixed with parent property if available.
+- Constant/enum item names are prefixed with parent type instead of path. 
+- Schema title is used for struct name instead of path where available.
+
+### Added
+- Optional support for `x-nullable` (Swagger 2.0), `nullable` (OpenAPI 3.0) properties to enable nullability.
+
+### Fixed
+- Type marker stripping from path was affecting regexps too.
+
 ## [0.4.7] - 2019-10-05
 
 ### Added
@@ -44,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed unnecessary regexp dependency, #7.
 
+[0.4.8]: https://github.com/swaggest/go-code-builder/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/swaggest/go-code-builder/compare/v0.4.6...v0.4.7
 [0.4.6]: https://github.com/swaggest/go-code-builder/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/swaggest/go-code-builder/compare/v0.4.4...v0.4.5

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	ignoreErrors:
 		- '#Access to an undefined property .*Swaggest\\JsonSchema\\NameMirror.+#'
+		- '#Access to an undefined property static\(.+#'
 		- '#Binary operation "." between string and bool|Swaggest\JsonSchema\SchemaContract results in an error.#'
 		- '#Binary operation "." between string and array<Swaggest\JsonSchema\SchemaContract>|bool|Swaggest\JsonSchema\SchemaContract|null results in an error.#'

--- a/src/JsonSchema/Options.php
+++ b/src/JsonSchema/Options.php
@@ -49,6 +49,12 @@ class Options extends ClassStructure
     public $ignoreXGoType = false;
 
     /**
+     * Add `null` to types if `x-nullable` or `nullable` is available.
+     * @var bool
+     */
+    public $enableXNullable = false;
+
+    /**
      * Use pointer types to avoid zero value ambiguity.
      * @var bool
      */
@@ -61,7 +67,7 @@ class Options extends ClassStructure
     public $ignoreNullable = false;
 
     /**
-     * @param static $properties
+     * @param Properties|static $properties
      * @param Schema $ownerSchema
      */
     public static function setUpProperties($properties, Schema $ownerSchema)

--- a/tests/resources/go/asyncapi-default/entities.go
+++ b/tests/resources/go/asyncapi-default/entities.go
@@ -15,7 +15,7 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Asyncapi      AsyncAPIAsyncapi       `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
 	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
 	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
 	Servers       []Server               `json:"servers,omitempty"`
@@ -1315,45 +1315,45 @@ func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
 	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
-// Asyncapi is an enum type.
-type Asyncapi string
+// AsyncAPIAsyncapi is an enum type.
+type AsyncAPIAsyncapi string
 
-// Asyncapi values enumeration.
+// AsyncAPIAsyncapi values enumeration.
 const (
-	Asyncapi100 = Asyncapi("1.0.0")
-	Asyncapi110 = Asyncapi("1.1.0")
-	Asyncapi120 = Asyncapi("1.2.0")
+	AsyncAPIAsyncapi100 = AsyncAPIAsyncapi("1.0.0")
+	AsyncAPIAsyncapi110 = AsyncAPIAsyncapi("1.1.0")
+	AsyncAPIAsyncapi120 = AsyncAPIAsyncapi("1.2.0")
 )
 
 // MarshalJSON encodes JSON.
-func (i Asyncapi) MarshalJSON() ([]byte, error) {
+func (i AsyncAPIAsyncapi) MarshalJSON() ([]byte, error) {
 	switch i {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return nil, fmt.Errorf("unexpected Asyncapi value: %v", i)
+		return nil, fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *Asyncapi) UnmarshalJSON(data []byte) error {
+func (i *AsyncAPIAsyncapi) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := Asyncapi(ii)
+	v := AsyncAPIAsyncapi(ii)
 	switch v {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return fmt.Errorf("unexpected Asyncapi value: %v", v)
+		return fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", v)
 	}
 
 	*i = v

--- a/tests/resources/go/asyncapi-default/entities_test.go
+++ b/tests/resources/go/asyncapi-default/entities_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_MarshalUnmarshal(t *testing.T) {
 	entity := AsyncAPI{
-		Asyncapi: Asyncapi120,
+		Asyncapi: AsyncAPIAsyncapi120,
 		Components: &Components{
 			SecuritySchemes: &ComponentsSecuritySchemes{
 				MapOfComponentsSecuritySchemesAZAZ09Values: map[string]ComponentsSecuritySchemesAZAZ09{
@@ -47,7 +47,7 @@ func Benchmark_Marshal(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		entity := AsyncAPI{
-			Asyncapi: Asyncapi120,
+			Asyncapi: AsyncAPIAsyncapi120,
 			Components: &Components{
 				SecuritySchemes: &ComponentsSecuritySchemes{
 					MapOfComponentsSecuritySchemesAZAZ09Values: map[string]ComponentsSecuritySchemesAZAZ09{

--- a/tests/resources/go/asyncapi-skip-marshal/entities.go
+++ b/tests/resources/go/asyncapi-skip-marshal/entities.go
@@ -13,7 +13,7 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Asyncapi      AsyncAPIAsyncapi       `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
 	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
 	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
 	Servers       []Server               `json:"servers,omitempty"`
@@ -1135,31 +1135,31 @@ func (i *ComponentsSecuritySchemes) UnmarshalJSON(data []byte) error {
 }
 
 
-// Asyncapi is an enum type.
-type Asyncapi string
+// AsyncAPIAsyncapi is an enum type.
+type AsyncAPIAsyncapi string
 
-// Asyncapi values enumeration.
+// AsyncAPIAsyncapi values enumeration.
 const (
-	Asyncapi100 = Asyncapi("1.0.0")
-	Asyncapi110 = Asyncapi("1.1.0")
-	Asyncapi120 = Asyncapi("1.2.0")
+	AsyncAPIAsyncapi100 = AsyncAPIAsyncapi("1.0.0")
+	AsyncAPIAsyncapi110 = AsyncAPIAsyncapi("1.1.0")
+	AsyncAPIAsyncapi120 = AsyncAPIAsyncapi("1.2.0")
 )
 
 // UnmarshalJSON decodes JSON.
-func (i *Asyncapi) UnmarshalJSON(data []byte) error {
+func (i *AsyncAPIAsyncapi) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := Asyncapi(ii)
+	v := AsyncAPIAsyncapi(ii)
 	switch v {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return fmt.Errorf("unexpected Asyncapi value: %v", v)
+		return fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", v)
 	}
 
 	*i = v

--- a/tests/resources/go/asyncapi-skip-unmarshal/entities.go
+++ b/tests/resources/go/asyncapi-skip-unmarshal/entities.go
@@ -13,7 +13,7 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Asyncapi      AsyncAPIAsyncapi       `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
 	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
 	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
 	Servers       []Server               `json:"servers,omitempty"`
@@ -560,25 +560,25 @@ func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
 	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
-// Asyncapi is an enum type.
-type Asyncapi string
+// AsyncAPIAsyncapi is an enum type.
+type AsyncAPIAsyncapi string
 
-// Asyncapi values enumeration.
+// AsyncAPIAsyncapi values enumeration.
 const (
-	Asyncapi100 = Asyncapi("1.0.0")
-	Asyncapi110 = Asyncapi("1.1.0")
-	Asyncapi120 = Asyncapi("1.2.0")
+	AsyncAPIAsyncapi100 = AsyncAPIAsyncapi("1.0.0")
+	AsyncAPIAsyncapi110 = AsyncAPIAsyncapi("1.1.0")
+	AsyncAPIAsyncapi120 = AsyncAPIAsyncapi("1.2.0")
 )
 
 // MarshalJSON encodes JSON.
-func (i Asyncapi) MarshalJSON() ([]byte, error) {
+func (i AsyncAPIAsyncapi) MarshalJSON() ([]byte, error) {
 	switch i {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return nil, fmt.Errorf("unexpected Asyncapi value: %v", i)
+		return nil, fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", i)
 	}
 
 	return json.Marshal(string(i))

--- a/tests/resources/go/asyncapi/entities.go
+++ b/tests/resources/go/asyncapi/entities.go
@@ -15,7 +15,7 @@ import (
 //
 // AsyncAPI 1.2.0 schema.
 type AsyncAPI struct {
-	Asyncapi      Asyncapi               `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
+	Asyncapi      AsyncAPIAsyncapi       `json:"asyncapi,omitempty"`     // The AsyncAPI specification version of this document.
 	Info          *Info                  `json:"info,omitempty"`         // General information about the API.
 	BaseTopic     string                 `json:"baseTopic,omitempty"`    // The base topic to the API. Example: 'hitch'.
 	Servers       []Server               `json:"servers,omitempty"`
@@ -1181,45 +1181,45 @@ func (i ComponentsSecuritySchemes) MarshalJSON() ([]byte, error) {
 	return marshalUnion(marshalComponentsSecuritySchemes(i), i.MapOfComponentsSecuritySchemesAZAZ09Values, i.AdditionalProperties)
 }
 
-// Asyncapi is an enum type.
-type Asyncapi string
+// AsyncAPIAsyncapi is an enum type.
+type AsyncAPIAsyncapi string
 
-// Asyncapi values enumeration.
+// AsyncAPIAsyncapi values enumeration.
 const (
-	Asyncapi100 = Asyncapi("1.0.0")
-	Asyncapi110 = Asyncapi("1.1.0")
-	Asyncapi120 = Asyncapi("1.2.0")
+	AsyncAPIAsyncapi100 = AsyncAPIAsyncapi("1.0.0")
+	AsyncAPIAsyncapi110 = AsyncAPIAsyncapi("1.1.0")
+	AsyncAPIAsyncapi120 = AsyncAPIAsyncapi("1.2.0")
 )
 
 // MarshalJSON encodes JSON.
-func (i Asyncapi) MarshalJSON() ([]byte, error) {
+func (i AsyncAPIAsyncapi) MarshalJSON() ([]byte, error) {
 	switch i {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return nil, fmt.Errorf("unexpected Asyncapi value: %v", i)
+		return nil, fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *Asyncapi) UnmarshalJSON(data []byte) error {
+func (i *AsyncAPIAsyncapi) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := Asyncapi(ii)
+	v := AsyncAPIAsyncapi(ii)
 	switch v {
-	case Asyncapi100:
-	case Asyncapi110:
-	case Asyncapi120:
+	case AsyncAPIAsyncapi100:
+	case AsyncAPIAsyncapi110:
+	case AsyncAPIAsyncapi120:
 
 	default:
-		return fmt.Errorf("unexpected Asyncapi value: %v", v)
+		return fmt.Errorf("unexpected AsyncAPIAsyncapi value: %v", v)
 	}
 
 	*i = v

--- a/tests/resources/go/asyncapi2/entities.go
+++ b/tests/resources/go/asyncapi2/entities.go
@@ -692,17 +692,17 @@ func (i OperationBindingsObject) MarshalJSON() ([]byte, error) {
 // This object contains information about the operation representation in AMQP.
 // See https://github.com/asyncapi/bindings/tree/master/amqp#operation-binding-object.
 type AMQP091OperationBindingObject struct {
-	Expiration     int64                                           `json:"expiration,omitempty"`     // TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero. Applies to Publish, Subscribe.
-	UserID         string                                          `json:"userId,omitempty"`         // Identifies the user who has sent the message. Applies to Publish, Subscribe.
-	Cc             []string                                        `json:"cc,omitempty"`             // The routing keys the message should be routed to at the time of publishing. Applies to Publish, Subscribe.
-	Priority       int64                                           `json:"priority,omitempty"`       // A priority for the message. Applies to Publish, Subscribe.
-	DeliveryMode   AmqpOperationBindingObject010JSONDeliveryMode   `json:"deliveryMode,omitempty"`   // Delivery mode of the message. Its value MUST be either 1 (transient) or 2 (persistent). Applies to Publish, Subscribe.
-	Mandatory      bool                                            `json:"mandatory,omitempty"`      // Whether the message is mandatory or not. Applies to Publish.
-	Bcc            []string                                        `json:"bcc,omitempty"`            // Like cc but consumers will not receive this information. Applies to Publish.
-	ReplyTo        string                                          `json:"replyTo,omitempty"`        // Name of the queue where the consumer should send the response. Applies to Publish, Subscribe.
-	Timestamp      bool                                            `json:"timestamp,omitempty"`      // Whether the message should include a timestamp or not. Applies to Publish, Subscribe.
-	Ack            bool                                            `json:"ack,omitempty"`            // Whether the consumer should ack the message or not. Applies to Subscribe.
-	BindingVersion AmqpOperationBindingObject010JSONBindingVersion `json:"bindingVersion,omitempty"` // The version of this binding. If omitted, "latest" MUST be assumed. Applies to Publish, Subscribe.
+	Expiration     int64                                       `json:"expiration,omitempty"`     // TTL (Time-To-Live) for the message. It MUST be greater than or equal to zero. Applies to Publish, Subscribe.
+	UserID         string                                      `json:"userId,omitempty"`         // Identifies the user who has sent the message. Applies to Publish, Subscribe.
+	Cc             []string                                    `json:"cc,omitempty"`             // The routing keys the message should be routed to at the time of publishing. Applies to Publish, Subscribe.
+	Priority       int64                                       `json:"priority,omitempty"`       // A priority for the message. Applies to Publish, Subscribe.
+	DeliveryMode   AMQP091OperationBindingObjectDeliveryMode   `json:"deliveryMode,omitempty"`   // Delivery mode of the message. Its value MUST be either 1 (transient) or 2 (persistent). Applies to Publish, Subscribe.
+	Mandatory      bool                                        `json:"mandatory,omitempty"`      // Whether the message is mandatory or not. Applies to Publish.
+	Bcc            []string                                    `json:"bcc,omitempty"`            // Like cc but consumers will not receive this information. Applies to Publish.
+	ReplyTo        string                                      `json:"replyTo,omitempty"`        // Name of the queue where the consumer should send the response. Applies to Publish, Subscribe.
+	Timestamp      bool                                        `json:"timestamp,omitempty"`      // Whether the message should include a timestamp or not. Applies to Publish, Subscribe.
+	Ack            bool                                        `json:"ack,omitempty"`            // Whether the consumer should ack the message or not. Applies to Subscribe.
+	BindingVersion AMQP091OperationBindingObjectBindingVersion `json:"bindingVersion,omitempty"` // The version of this binding. If omitted, "latest" MUST be assumed. Applies to Publish, Subscribe.
 }
 
 // OperationTraitsItems structure is generated from "#/definitions/operation->traits->items".
@@ -938,9 +938,9 @@ func (i MessageBindingsObject) MarshalJSON() ([]byte, error) {
 // This object contains information about the message representation in AMQP.
 // See https://github.com/asyncapi/bindings/tree/master/amqp#message-binding-object.
 type AMQP091MessageBindingObject struct {
-	ContentEncoding string                                        `json:"contentEncoding,omitempty"` // A MIME encoding for the message content.
-	MessageType     string                                        `json:"messageType,omitempty"`     // Application-specific message type.
-	BindingVersion  AmqpMessageBindingObject010JSONBindingVersion `json:"bindingVersion,omitempty"`  // The version of this binding. If omitted, "latest" MUST be assumed.
+	ContentEncoding string                                    `json:"contentEncoding,omitempty"` // A MIME encoding for the message content.
+	MessageType     string                                    `json:"messageType,omitempty"`     // Application-specific message type.
+	BindingVersion  AMQP091MessageBindingObjectBindingVersion `json:"bindingVersion,omitempty"`  // The version of this binding. If omitted, "latest" MUST be assumed.
 }
 
 // MessageTrait structure is generated from "#/definitions/messageTrait".
@@ -1221,10 +1221,10 @@ func (i ChannelBindingsObject) MarshalJSON() ([]byte, error) {
 // This object contains information about the channel representation in AMQP.
 // See https://github.com/asyncapi/bindings/tree/master/amqp#channel-binding-object.
 type AMQP091ChannelBindingObject struct {
-	Is             AmqpChannelBindingObject010JSONIs             `json:"is,omitempty"`             // Defines what type of channel is it. Can be either `queue` or `routingKey` (default).
-	Exchange       *Exchange                                     `json:"exchange,omitempty"`       // When `is`=`routingKey`, this object defines the exchange properties.
-	Queue          *Queue                                        `json:"queue,omitempty"`          // When `is`=`queue`, this object defines the queue properties.
-	BindingVersion AmqpChannelBindingObject010JSONBindingVersion `json:"bindingVersion,omitempty"` // The version of this binding. If omitted, "latest" MUST be assumed.
+	Is             AMQP091ChannelBindingObjectIs             `json:"is,omitempty"`             // Defines what type of channel is it. Can be either `queue` or `routingKey` (default).
+	Exchange       *Exchange                                 `json:"exchange,omitempty"`       // When `is`=`routingKey`, this object defines the exchange properties.
+	Queue          *Queue                                    `json:"queue,omitempty"`          // When `is`=`queue`, this object defines the queue properties.
+	BindingVersion AMQP091ChannelBindingObjectBindingVersion `json:"bindingVersion,omitempty"` // The version of this binding. If omitted, "latest" MUST be assumed.
 }
 
 // Exchange structure is generated from "#/definitions/exchange".
@@ -2044,168 +2044,168 @@ func (i ComponentsCorrelationIds) MarshalJSON() ([]byte, error) {
 	return marshalUnion(marshalComponentsCorrelationIds(i), i.MapOfComponentsCorrelationIdsWDValues, i.AdditionalProperties)
 }
 
-// AmqpOperationBindingObject010JSONDeliveryMode is an enum type.
-type AmqpOperationBindingObject010JSONDeliveryMode int64
+// AMQP091OperationBindingObjectDeliveryMode is an enum type.
+type AMQP091OperationBindingObjectDeliveryMode int64
 
-// AmqpOperationBindingObject010JSONDeliveryMode values enumeration.
+// AMQP091OperationBindingObjectDeliveryMode values enumeration.
 const (
-	AmqpOperationBindingObject010JSONDeliveryModeTransient = AmqpOperationBindingObject010JSONDeliveryMode(1)
-	AmqpOperationBindingObject010JSONDeliveryModePersistent = AmqpOperationBindingObject010JSONDeliveryMode(2)
+	AMQP091OperationBindingObjectDeliveryModeTransient = AMQP091OperationBindingObjectDeliveryMode(1)
+	AMQP091OperationBindingObjectDeliveryModePersistent = AMQP091OperationBindingObjectDeliveryMode(2)
 )
 
 // MarshalJSON encodes JSON.
-func (i AmqpOperationBindingObject010JSONDeliveryMode) MarshalJSON() ([]byte, error) {
+func (i AMQP091OperationBindingObjectDeliveryMode) MarshalJSON() ([]byte, error) {
 	switch i {
-	case AmqpOperationBindingObject010JSONDeliveryModeTransient:
-	case AmqpOperationBindingObject010JSONDeliveryModePersistent:
+	case AMQP091OperationBindingObjectDeliveryModeTransient:
+	case AMQP091OperationBindingObjectDeliveryModePersistent:
 
 	default:
-		return nil, fmt.Errorf("unexpected AmqpOperationBindingObject010JSONDeliveryMode value: %v", i)
+		return nil, fmt.Errorf("unexpected AMQP091OperationBindingObjectDeliveryMode value: %v", i)
 	}
 
 	return json.Marshal(int64(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *AmqpOperationBindingObject010JSONDeliveryMode) UnmarshalJSON(data []byte) error {
+func (i *AMQP091OperationBindingObjectDeliveryMode) UnmarshalJSON(data []byte) error {
 	var ii int64
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := AmqpOperationBindingObject010JSONDeliveryMode(ii)
+	v := AMQP091OperationBindingObjectDeliveryMode(ii)
 	switch v {
-	case AmqpOperationBindingObject010JSONDeliveryModeTransient:
-	case AmqpOperationBindingObject010JSONDeliveryModePersistent:
+	case AMQP091OperationBindingObjectDeliveryModeTransient:
+	case AMQP091OperationBindingObjectDeliveryModePersistent:
 
 	default:
-		return fmt.Errorf("unexpected AmqpOperationBindingObject010JSONDeliveryMode value: %v", v)
+		return fmt.Errorf("unexpected AMQP091OperationBindingObjectDeliveryMode value: %v", v)
 	}
 
 	*i = v
 	return nil
 }
 
-// AmqpOperationBindingObject010JSONBindingVersion is an enum type.
-type AmqpOperationBindingObject010JSONBindingVersion string
+// AMQP091OperationBindingObjectBindingVersion is an enum type.
+type AMQP091OperationBindingObjectBindingVersion string
 
-// AmqpOperationBindingObject010JSONBindingVersion values enumeration.
+// AMQP091OperationBindingObjectBindingVersion values enumeration.
 const (
-	AmqpOperationBindingObject010JSONBindingVersion010 = AmqpOperationBindingObject010JSONBindingVersion("0.1.0")
-	AmqpOperationBindingObject010JSONBindingVersionLatest = AmqpOperationBindingObject010JSONBindingVersion("latest")
+	AMQP091OperationBindingObjectBindingVersion010 = AMQP091OperationBindingObjectBindingVersion("0.1.0")
+	AMQP091OperationBindingObjectBindingVersionLatest = AMQP091OperationBindingObjectBindingVersion("latest")
 )
 
 // MarshalJSON encodes JSON.
-func (i AmqpOperationBindingObject010JSONBindingVersion) MarshalJSON() ([]byte, error) {
+func (i AMQP091OperationBindingObjectBindingVersion) MarshalJSON() ([]byte, error) {
 	switch i {
-	case AmqpOperationBindingObject010JSONBindingVersion010:
-	case AmqpOperationBindingObject010JSONBindingVersionLatest:
+	case AMQP091OperationBindingObjectBindingVersion010:
+	case AMQP091OperationBindingObjectBindingVersionLatest:
 
 	default:
-		return nil, fmt.Errorf("unexpected AmqpOperationBindingObject010JSONBindingVersion value: %v", i)
+		return nil, fmt.Errorf("unexpected AMQP091OperationBindingObjectBindingVersion value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *AmqpOperationBindingObject010JSONBindingVersion) UnmarshalJSON(data []byte) error {
+func (i *AMQP091OperationBindingObjectBindingVersion) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := AmqpOperationBindingObject010JSONBindingVersion(ii)
+	v := AMQP091OperationBindingObjectBindingVersion(ii)
 	switch v {
-	case AmqpOperationBindingObject010JSONBindingVersion010:
-	case AmqpOperationBindingObject010JSONBindingVersionLatest:
+	case AMQP091OperationBindingObjectBindingVersion010:
+	case AMQP091OperationBindingObjectBindingVersionLatest:
 
 	default:
-		return fmt.Errorf("unexpected AmqpOperationBindingObject010JSONBindingVersion value: %v", v)
+		return fmt.Errorf("unexpected AMQP091OperationBindingObjectBindingVersion value: %v", v)
 	}
 
 	*i = v
 	return nil
 }
 
-// AmqpMessageBindingObject010JSONBindingVersion is an enum type.
-type AmqpMessageBindingObject010JSONBindingVersion string
+// AMQP091MessageBindingObjectBindingVersion is an enum type.
+type AMQP091MessageBindingObjectBindingVersion string
 
-// AmqpMessageBindingObject010JSONBindingVersion values enumeration.
+// AMQP091MessageBindingObjectBindingVersion values enumeration.
 const (
-	AmqpMessageBindingObject010JSONBindingVersion010 = AmqpMessageBindingObject010JSONBindingVersion("0.1.0")
-	AmqpMessageBindingObject010JSONBindingVersionLatest = AmqpMessageBindingObject010JSONBindingVersion("latest")
+	AMQP091MessageBindingObjectBindingVersion010 = AMQP091MessageBindingObjectBindingVersion("0.1.0")
+	AMQP091MessageBindingObjectBindingVersionLatest = AMQP091MessageBindingObjectBindingVersion("latest")
 )
 
 // MarshalJSON encodes JSON.
-func (i AmqpMessageBindingObject010JSONBindingVersion) MarshalJSON() ([]byte, error) {
+func (i AMQP091MessageBindingObjectBindingVersion) MarshalJSON() ([]byte, error) {
 	switch i {
-	case AmqpMessageBindingObject010JSONBindingVersion010:
-	case AmqpMessageBindingObject010JSONBindingVersionLatest:
+	case AMQP091MessageBindingObjectBindingVersion010:
+	case AMQP091MessageBindingObjectBindingVersionLatest:
 
 	default:
-		return nil, fmt.Errorf("unexpected AmqpMessageBindingObject010JSONBindingVersion value: %v", i)
+		return nil, fmt.Errorf("unexpected AMQP091MessageBindingObjectBindingVersion value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *AmqpMessageBindingObject010JSONBindingVersion) UnmarshalJSON(data []byte) error {
+func (i *AMQP091MessageBindingObjectBindingVersion) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := AmqpMessageBindingObject010JSONBindingVersion(ii)
+	v := AMQP091MessageBindingObjectBindingVersion(ii)
 	switch v {
-	case AmqpMessageBindingObject010JSONBindingVersion010:
-	case AmqpMessageBindingObject010JSONBindingVersionLatest:
+	case AMQP091MessageBindingObjectBindingVersion010:
+	case AMQP091MessageBindingObjectBindingVersionLatest:
 
 	default:
-		return fmt.Errorf("unexpected AmqpMessageBindingObject010JSONBindingVersion value: %v", v)
+		return fmt.Errorf("unexpected AMQP091MessageBindingObjectBindingVersion value: %v", v)
 	}
 
 	*i = v
 	return nil
 }
 
-// AmqpChannelBindingObject010JSONIs is an enum type.
-type AmqpChannelBindingObject010JSONIs string
+// AMQP091ChannelBindingObjectIs is an enum type.
+type AMQP091ChannelBindingObjectIs string
 
-// AmqpChannelBindingObject010JSONIs values enumeration.
+// AMQP091ChannelBindingObjectIs values enumeration.
 const (
-	AmqpChannelBindingObject010JSONIsRoutingKey = AmqpChannelBindingObject010JSONIs("routingKey")
-	AmqpChannelBindingObject010JSONIsQueue = AmqpChannelBindingObject010JSONIs("queue")
+	AMQP091ChannelBindingObjectIsRoutingKey = AMQP091ChannelBindingObjectIs("routingKey")
+	AMQP091ChannelBindingObjectIsQueue = AMQP091ChannelBindingObjectIs("queue")
 )
 
 // MarshalJSON encodes JSON.
-func (i AmqpChannelBindingObject010JSONIs) MarshalJSON() ([]byte, error) {
+func (i AMQP091ChannelBindingObjectIs) MarshalJSON() ([]byte, error) {
 	switch i {
-	case AmqpChannelBindingObject010JSONIsRoutingKey:
-	case AmqpChannelBindingObject010JSONIsQueue:
+	case AMQP091ChannelBindingObjectIsRoutingKey:
+	case AMQP091ChannelBindingObjectIsQueue:
 
 	default:
-		return nil, fmt.Errorf("unexpected AmqpChannelBindingObject010JSONIs value: %v", i)
+		return nil, fmt.Errorf("unexpected AMQP091ChannelBindingObjectIs value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *AmqpChannelBindingObject010JSONIs) UnmarshalJSON(data []byte) error {
+func (i *AMQP091ChannelBindingObjectIs) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := AmqpChannelBindingObject010JSONIs(ii)
+	v := AMQP091ChannelBindingObjectIs(ii)
 	switch v {
-	case AmqpChannelBindingObject010JSONIsRoutingKey:
-	case AmqpChannelBindingObject010JSONIsQueue:
+	case AMQP091ChannelBindingObjectIsRoutingKey:
+	case AMQP091ChannelBindingObjectIsQueue:
 
 	default:
-		return fmt.Errorf("unexpected AmqpChannelBindingObject010JSONIs value: %v", v)
+		return fmt.Errorf("unexpected AMQP091ChannelBindingObjectIs value: %v", v)
 	}
 
 	*i = v
@@ -2263,42 +2263,42 @@ func (i *ExchangeType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// AmqpChannelBindingObject010JSONBindingVersion is an enum type.
-type AmqpChannelBindingObject010JSONBindingVersion string
+// AMQP091ChannelBindingObjectBindingVersion is an enum type.
+type AMQP091ChannelBindingObjectBindingVersion string
 
-// AmqpChannelBindingObject010JSONBindingVersion values enumeration.
+// AMQP091ChannelBindingObjectBindingVersion values enumeration.
 const (
-	AmqpChannelBindingObject010JSONBindingVersion010 = AmqpChannelBindingObject010JSONBindingVersion("0.1.0")
-	AmqpChannelBindingObject010JSONBindingVersionLatest = AmqpChannelBindingObject010JSONBindingVersion("latest")
+	AMQP091ChannelBindingObjectBindingVersion010 = AMQP091ChannelBindingObjectBindingVersion("0.1.0")
+	AMQP091ChannelBindingObjectBindingVersionLatest = AMQP091ChannelBindingObjectBindingVersion("latest")
 )
 
 // MarshalJSON encodes JSON.
-func (i AmqpChannelBindingObject010JSONBindingVersion) MarshalJSON() ([]byte, error) {
+func (i AMQP091ChannelBindingObjectBindingVersion) MarshalJSON() ([]byte, error) {
 	switch i {
-	case AmqpChannelBindingObject010JSONBindingVersion010:
-	case AmqpChannelBindingObject010JSONBindingVersionLatest:
+	case AMQP091ChannelBindingObjectBindingVersion010:
+	case AMQP091ChannelBindingObjectBindingVersionLatest:
 
 	default:
-		return nil, fmt.Errorf("unexpected AmqpChannelBindingObject010JSONBindingVersion value: %v", i)
+		return nil, fmt.Errorf("unexpected AMQP091ChannelBindingObjectBindingVersion value: %v", i)
 	}
 
 	return json.Marshal(string(i))
 }
 
 // UnmarshalJSON decodes JSON.
-func (i *AmqpChannelBindingObject010JSONBindingVersion) UnmarshalJSON(data []byte) error {
+func (i *AMQP091ChannelBindingObjectBindingVersion) UnmarshalJSON(data []byte) error {
 	var ii string
 	err := json.Unmarshal(data, &ii)
 	if err != nil {
 		return err
 	}
-	v := AmqpChannelBindingObject010JSONBindingVersion(ii)
+	v := AMQP091ChannelBindingObjectBindingVersion(ii)
 	switch v {
-	case AmqpChannelBindingObject010JSONBindingVersion010:
-	case AmqpChannelBindingObject010JSONBindingVersionLatest:
+	case AMQP091ChannelBindingObjectBindingVersion010:
+	case AMQP091ChannelBindingObjectBindingVersionLatest:
 
 	default:
-		return fmt.Errorf("unexpected AmqpChannelBindingObject010JSONBindingVersion value: %v", v)
+		return fmt.Errorf("unexpected AMQP091ChannelBindingObjectBindingVersion value: %v", v)
 	}
 
 	*i = v

--- a/tests/src/PHPUnit/JsonSchema/AsyncApiTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AsyncApiTest.php
@@ -16,7 +16,9 @@ class AsyncApiTest extends \PHPUnit_Framework_TestCase
     public function testGen()
     {
         $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/asyncapi.json'));
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
 
 
         $builder = new GoBuilder();
@@ -48,7 +50,9 @@ class AsyncApiTest extends \PHPUnit_Framework_TestCase
     public function testGenConst()
     {
         $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/asyncapi.json'));
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
 
 
         $builder = new GoBuilder();
@@ -81,7 +85,9 @@ class AsyncApiTest extends \PHPUnit_Framework_TestCase
     public function testGenSkipMarshal()
     {
         $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/asyncapi.json'));
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
 
 
         $builder = new GoBuilder();
@@ -113,7 +119,9 @@ class AsyncApiTest extends \PHPUnit_Framework_TestCase
     public function testGenSkipUnmarshal()
     {
         $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/asyncapi.json'));
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
 
 
         $builder = new GoBuilder();

--- a/tests/src/PHPUnit/JsonSchema/JsonSchemaGenerateTest.php
+++ b/tests/src/PHPUnit/JsonSchema/JsonSchemaGenerateTest.php
@@ -7,6 +7,8 @@ use Swaggest\GoCodeBuilder\JsonSchema\GoBuilder;
 use Swaggest\GoCodeBuilder\JsonSchema\StructHookCallback;
 use Swaggest\GoCodeBuilder\Templates\GoFile;
 use Swaggest\GoCodeBuilder\Templates\Struct\StructDef;
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\RemoteRef\Preloaded;
 use Swaggest\JsonSchema\Schema;
 
 class JsonSchemaGenerateTest extends \PHPUnit_Framework_TestCase
@@ -45,7 +47,9 @@ class JsonSchemaGenerateTest extends \PHPUnit_Framework_TestCase
 
     public function testNonNegativeIntegerDefault0()
     {
-        $schema = Schema::import('http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0');
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import('http://json-schema.org/draft-07/schema#/definitions/nonNegativeIntegerDefault0', $context);
 
         $builder = new GoBuilder();
         $builder->options->hideConstProperties = true;

--- a/tests/src/PHPUnit/JsonSchema/SwaggerSchemaGenerateTest.php
+++ b/tests/src/PHPUnit/JsonSchema/SwaggerSchemaGenerateTest.php
@@ -7,6 +7,8 @@ use Swaggest\GoCodeBuilder\JsonSchema\GoBuilder;
 use Swaggest\GoCodeBuilder\JsonSchema\StructHookCallback;
 use Swaggest\GoCodeBuilder\Templates\GoFile;
 use Swaggest\GoCodeBuilder\Templates\Struct\StructDef;
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\RemoteRef\Preloaded;
 use Swaggest\JsonSchema\Schema;
 
 class SwaggerSchemaGenerateTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +16,9 @@ class SwaggerSchemaGenerateTest extends \PHPUnit_Framework_TestCase
     public function testGen()
     {
         $schemaData = json_decode(file_get_contents(__DIR__ . '/../../../resources/swagger-schema.json'));
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
 
 
         $builder = new GoBuilder();

--- a/tests/src/PHPUnit/JsonSchema/TypeBuilderTest.php
+++ b/tests/src/PHPUnit/JsonSchema/TypeBuilderTest.php
@@ -5,6 +5,8 @@ namespace Swaggest\GoCodeBuilder\Tests\PHPUnit\JsonSchema;
 
 use Swaggest\GoCodeBuilder\JsonSchema\GoBuilder;
 use Swaggest\GoCodeBuilder\JsonSchema\TypeBuilder;
+use Swaggest\JsonSchema\Context;
+use Swaggest\JsonSchema\RemoteRef\Preloaded;
 use Swaggest\JsonSchema\Schema;
 
 class TypeBuilderTest extends \PHPUnit_Framework_TestCase
@@ -32,7 +34,9 @@ class TypeBuilderTest extends \PHPUnit_Framework_TestCase
 }
 JSON
         );
-        $schema = Schema::import($schemaData);
+        $refResolver = new Preloaded();
+        $context = new Context($refResolver);
+        $schema = Schema::import($schemaData, $context);
         $goBuilder = new GoBuilder();
         $type = $goBuilder->getType($schema);
 


### PR DESCRIPTION
### Changed
- Constant/enum type names are prefixed with parent property if available.
- Constant/enum item names are prefixed with parent type instead of path. 
- Schema title is used for struct name instead of path where available.

### Added
- Optional support for `x-nullable` (Swagger 2.0), `nullable` (OpenAPI 3.0) properties to enable nullability.

### Fixed
- Type marker stripping from path was affecting regexps too.
