### PR TITLE
Fix dereference of `nil` `*json.RawMessage` in properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.11] - 2019-10-15
+
+### Fixed
+- Dereference of `nil` `*json.RawMessage` in additional and pattern properties.
+
 ## [0.4.10] - 2019-10-15
 
 ### Added
@@ -68,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed unnecessary regexp dependency, #7.
 
+[0.4.11]: https://github.com/swaggest/go-code-builder/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/swaggest/go-code-builder/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/swaggest/go-code-builder/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/swaggest/go-code-builder/compare/v0.4.7...v0.4.8

--- a/src/JsonSchema/UnmarshalUnion.php
+++ b/src/JsonSchema/UnmarshalUnion.php
@@ -168,7 +168,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -203,7 +207,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/advanced/entities.go
+++ b/tests/resources/go/advanced/entities.go
@@ -430,7 +430,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -462,7 +466,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/asyncapi-data/entities.go
+++ b/tests/resources/go/asyncapi-data/entities.go
@@ -291,7 +291,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 

--- a/tests/resources/go/asyncapi-default/entities.go
+++ b/tests/resources/go/asyncapi-default/entities.go
@@ -1683,7 +1683,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -1715,7 +1719,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/asyncapi-skip-marshal/entities.go
+++ b/tests/resources/go/asyncapi-skip-marshal/entities.go
@@ -1384,7 +1384,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -1416,7 +1420,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/asyncapi/entities.go
+++ b/tests/resources/go/asyncapi/entities.go
@@ -2017,7 +2017,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -2049,7 +2053,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/asyncapi2/entities.go
+++ b/tests/resources/go/asyncapi2/entities.go
@@ -2507,7 +2507,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -2539,7 +2543,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/draft7/entities.go
+++ b/tests/resources/go/draft7/entities.go
@@ -415,7 +415,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 

--- a/tests/resources/go/openapi3/entities.go
+++ b/tests/resources/go/openapi3/entities.go
@@ -3332,7 +3332,11 @@ func (u unionMap) unmarshalAdditionalProperties(m map[string]*json.RawMessage) e
 			subMap = append(subMap[:len(subMap)-1], ',')
 		}
 		subMap = append(subMap, []byte(keyEscaped)...)
-		subMap = append(subMap, []byte(*val)...)
+		if val != nil {
+			subMap = append(subMap, []byte(*val)...)
+		} else {
+			subMap = append(subMap, []byte("null")...)
+		}
 		subMap = append(subMap, '}')
 	}
 
@@ -3364,7 +3368,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap

--- a/tests/resources/go/swagger/entities.go
+++ b/tests/resources/go/swagger/entities.go
@@ -2490,7 +2490,11 @@ func (u unionMap) unmarshalPatternProperties(m map[string]*json.RawMessage) erro
 				}
 
 				subMap = append(subMap, []byte(keyEscaped)...)
-				subMap = append(subMap, []byte(*val)...)
+				if val != nil {
+					subMap = append(subMap, []byte(*val)...)
+				} else {
+					subMap = append(subMap, []byte("null")...)
+				}
 				subMap = append(subMap, '}')
 
 				patternMapsRaw[regex] = subMap


### PR DESCRIPTION
### Fixed
- Dereference of `nil` `*json.RawMessage` in additional and pattern properties.