### PR TITLE
Add option to `$inheritSchemaFromExamples` when type and properties a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.12] - 2019-10-22
+
+### Changed
+- Names for logical branches are inherited from reference names where available.
+
+### Added
+- Option to `$inheritSchemaFromExamples` when type and properties are missing.
+
+### Fixed
+- Invalid property name when stripping parent prefix.
+
 ## [0.4.11] - 2019-10-15
 
 ### Fixed
@@ -73,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed unnecessary regexp dependency, #7.
 
+[0.4.12]: https://github.com/swaggest/go-code-builder/compare/v0.4.11...v0.4.12
 [0.4.11]: https://github.com/swaggest/go-code-builder/compare/v0.4.10...v0.4.11
 [0.4.10]: https://github.com/swaggest/go-code-builder/compare/v0.4.9...v0.4.10
 [0.4.9]: https://github.com/swaggest/go-code-builder/compare/v0.4.8...v0.4.9

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "swaggest/code-builder": "^0.3.1|dev-master",
     "php": ">=5.6.0",
     "phplang/scope-exit": "^1.0",
-    "swaggest/json-schema": "^0.12.4"
+    "swaggest/json-schema": "^0.12.4",
+    "swaggest/json-schema-maker": "^0.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba0a98cc0cb7eb67c6a46267e9468461",
+    "content-hash": "b1b87d431553fb3c3c8470300050ec3d",
     "packages": [
         {
             "name": "php-yaoi/php-yaoi",
@@ -232,16 +232,16 @@
         },
         {
             "name": "swaggest/json-schema",
-            "version": "v0.12.21",
+            "version": "v0.12.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swaggest/php-json-schema.git",
-                "reference": "2b2e7c953e953ff2436f950908fe4ccf03125713"
+                "reference": "d6ed96bd74d404129d3c5548e416beab2f9b2435"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swaggest/php-json-schema/zipball/2b2e7c953e953ff2436f950908fe4ccf03125713",
-                "reference": "2b2e7c953e953ff2436f950908fe4ccf03125713",
+                "url": "https://api.github.com/repos/swaggest/php-json-schema/zipball/d6ed96bd74d404129d3c5548e416beab2f9b2435",
+                "reference": "d6ed96bd74d404129d3c5548e416beab2f9b2435",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,53 @@
                 }
             ],
             "description": "High definition PHP structures with JSON-schema based validation",
-            "time": "2019-10-01T13:37:46+00:00"
+            "time": "2019-10-22T07:10:34+00:00"
+        },
+        {
+            "name": "swaggest/json-schema-maker",
+            "version": "v0.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/json-schema-maker.git",
+                "reference": "4336134bb9e8890d0b6eea5dab51660a82c2b142"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/json-schema-maker/zipball/4336134bb9e8890d0b6eea5dab51660a82c2b142",
+                "reference": "4336134bb9e8890d0b6eea5dab51660a82c2b142",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.5.0",
+                "swaggest/json-schema": "^0.12.21"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonSchemaMaker\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com",
+                    "homepage": "https://github.com/vearutop"
+                }
+            ],
+            "description": "Instance to JSON schema and back",
+            "homepage": "https://github.com/swaggest/json-schema-maker",
+            "keywords": [
+                "json-schema"
+            ],
+            "time": "2019-10-03T23:40:03+00:00"
         }
     ],
     "packages-dev": [

--- a/src/GoCodeBuilder.php
+++ b/src/GoCodeBuilder.php
@@ -69,7 +69,7 @@ GO;
     }
 
 
-    public function exportableName($name)
+    public function exportableName($name, $requireBase = false)
     {
         /** @var string $goName */
         $goName = preg_replace("/([^a-zA-Z0-9_]+)/", "_", $name);
@@ -77,6 +77,10 @@ GO;
         if ($goName === 'String') {
             $goName = 'StringProperty';
         }
+        if (!$goName && $requireBase) {
+            return '';
+        }
+
         if (!$goName) {
             $goName = 'Property' . substr(md5($name), 0, 6);
         } elseif (is_numeric($goName[0])) {

--- a/src/JsonSchema/GoBuilder.php
+++ b/src/JsonSchema/GoBuilder.php
@@ -72,6 +72,10 @@ class GoBuilder
      */
     public function getType($schema, $path = '#', StructDef $parentStruct = null)
     {
+        if (isset($this->generatedStructs[$path])) {
+            return $this->generatedStructs[$path]->structDef->getType();
+        }
+
         $s = self::unboolSchema($schema);
         if ($s instanceof Wrapper) {
             $path = $s->getObjectItemClass();
@@ -197,8 +201,13 @@ class GoBuilder
                 $fieldName = $this->codeBuilder->exportableName($name);
 
                 if ($this->options->trimParentFromPropertyNames) {
-                    if (strpos($fieldName, $structDef->getName()) === 0 && $fieldName !== $structDef->getName()) {
-                        $fieldName = substr($fieldName, strlen($structDef->getName()));
+                    $stripped = substr($fieldName, strlen($structDef->getName()));
+                    if (
+                        strpos($fieldName, $structDef->getName()) === 0
+                        && $fieldName !== $structDef->getName()
+                        && $stripped === $this->codeBuilder->exportableName($stripped)
+                    ) {
+                        $fieldName = $stripped;
                     }
                 }
 

--- a/src/JsonSchema/Options.php
+++ b/src/JsonSchema/Options.php
@@ -73,6 +73,12 @@ class Options extends ClassStructure
     public $defaultAdditionalProperties = true;
 
     /**
+     * Inherit schema from schema examples where available.
+     * @var bool
+     */
+    public $inheritSchemaFromExamples = false;
+
+    /**
      * @param Properties|static $properties
      * @param Schema $ownerSchema
      */

--- a/tests/resources/advanced.json
+++ b/tests/resources/advanced.json
@@ -3,6 +3,73 @@
   "$id": "props.json",
   "type": "object",
   "definitions": {
+    "refOrSchema": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/reference"
+        },
+        {
+          "$ref": "#/definitions/schema"
+        }
+      ]
+    },
+    "reference": {
+      "type": "object",
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/referenceObject"
+        }
+      }
+    },
+    "referenceObject": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "schema": {
+      "type": "object",
+      "x-go-type": "map[string]interface{}"
+    },
+    "noTypeWithExamples": {
+      "examples": [
+        {
+          "firstName": "John",
+          "lastName": "Doe",
+          "age": 30
+        },
+        {
+          "firstName": "Sarah",
+          "lastName": "Connor",
+          "age": null,
+          "gender": "F"
+        }
+      ]
+    },
+    "noTypeWithExample": {
+      "example": {
+        "firstName": "John",
+        "lastName": "Doe",
+        "age": 30
+      }
+    },
+    "address": {
+      "properties": {
+        "addressStripped": {
+          "type": "string"
+        },
+        "address1": {
+          "type": "string"
+        },
+        "address2": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        }
+      }
+    },
     "stringedType": {
       "type": "string",
       "enum": [
@@ -111,6 +178,18 @@
     }
   },
   "properties": {
+    "refOrSchema": {
+      "$ref": "#/definitions/refOrSchema"
+    },
+    "noTypeWithExamples": {
+      "$ref": "#/definitions/noTypeWithExamples"
+    },
+    "noTypeWithExample": {
+      "$ref": "#/definitions/noTypeWithExample"
+    },
+    "address": {
+      "$ref": "#/definitions/address"
+    },
     "headers": {
       "$ref": "#/definitions/table",
       "description": "message header field table"

--- a/tests/resources/go/advanced/entities.go
+++ b/tests/resources/go/advanced/entities.go
@@ -14,6 +14,10 @@ import (
 
 // Properties structure is generated from "#".
 type Properties struct {
+	RefOrSchema          *RefOrSchema           `json:"refOrSchema,omitempty"`
+	NoTypeWithExamples   *NoTypeWithExamples    `json:"noTypeWithExamples,omitempty"`
+	NoTypeWithExample    *NoTypeWithExample     `json:"noTypeWithExample,omitempty"`
+	Address              *Address               `json:"address,omitempty"`
 	Headers              *Table                 `json:"headers,omitempty"`
 	ContentType          *ShortStr              `json:"content-type,omitempty"`
 	ContentEncoding      *ShortStr              `json:"content-encoding,omitempty"`
@@ -27,8 +31,8 @@ type Properties struct {
 	Type                 *ShortStr              `json:"type,omitempty"`
 	UserID               *ShortStr              `json:"user-id,omitempty"`
 	AppID                *ShortStr              `json:"app-id,omitempty"`
-	MapOfAnything        map[string]interface{} `json:"-"`                          // Key must match pattern: ^x-
-	AdditionalProperties map[string]Property    `json:"-"`                          // All unmatched properties
+	MapOfAnything        map[string]interface{} `json:"-"`                            // Key must match pattern: ^x-
+	AdditionalProperties map[string]Property    `json:"-"`                            // All unmatched properties
 }
 
 type marshalProperties Properties
@@ -40,6 +44,10 @@ func (i *Properties) UnmarshalJSON(data []byte) error {
 	err := unionMap{
 		mustUnmarshal: []interface{}{&ii},
 		ignoreKeys: []string{
+			"refOrSchema",
+			"noTypeWithExamples",
+			"noTypeWithExample",
+			"address",
 			"headers",
 			"content-type",
 			"content-encoding",
@@ -70,6 +78,180 @@ func (i *Properties) UnmarshalJSON(data []byte) error {
 // MarshalJSON encodes JSON.
 func (i Properties) MarshalJSON() ([]byte, error) {
 	return marshalUnion(marshalProperties(i), i.MapOfAnything, i.AdditionalProperties)
+}
+
+// Reference structure is generated from "#/definitions/reference".
+type Reference struct {
+	Ref                  string                 `json:"$ref,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`              // All unmatched properties
+}
+
+type marshalReference Reference
+
+// UnmarshalJSON decodes JSON.
+func (i *Reference) UnmarshalJSON(data []byte) error {
+	ii := marshalReference(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"$ref",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Reference(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Reference) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalReference(i), i.AdditionalProperties)
+}
+
+// RefOrSchema structure is generated from "#/definitions/refOrSchema".
+type RefOrSchema struct {
+	Reference *Reference             `json:"-"`
+	Schema    map[string]interface{} `json:"-"`
+}
+
+type marshalRefOrSchema RefOrSchema
+
+// UnmarshalJSON decodes JSON.
+func (i *RefOrSchema) UnmarshalJSON(data []byte) error {
+	mayUnmarshal := []interface{}{&i.Reference, &i.Schema}
+	err := unionMap{
+		mayUnmarshal: mayUnmarshal,
+		jsonData: data,
+	}.unmarshal()
+	if mayUnmarshal[0] == nil {
+		i.Reference = nil
+	}
+	if mayUnmarshal[1] == nil {
+		i.Schema = nil
+	}
+
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i RefOrSchema) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalRefOrSchema(i), i.Reference, i.Schema)
+}
+
+// NoTypeWithExamples structure is generated from "#/definitions/noTypeWithExamples".
+type NoTypeWithExamples struct {
+	FirstName            string                 `json:"firstName,omitempty"`
+	LastName             string                 `json:"lastName,omitempty"`
+	Age                  *int64                 `json:"age"`
+	Gender               string                 `json:"gender,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`                   // All unmatched properties
+}
+
+type marshalNoTypeWithExamples NoTypeWithExamples
+
+// UnmarshalJSON decodes JSON.
+func (i *NoTypeWithExamples) UnmarshalJSON(data []byte) error {
+	ii := marshalNoTypeWithExamples(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"firstName",
+			"lastName",
+			"age",
+			"gender",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = NoTypeWithExamples(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i NoTypeWithExamples) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalNoTypeWithExamples(i), i.AdditionalProperties)
+}
+
+// NoTypeWithExample structure is generated from "#/definitions/noTypeWithExample".
+type NoTypeWithExample struct {
+	FirstName            string                 `json:"firstName,omitempty"`
+	LastName             string                 `json:"lastName,omitempty"`
+	Age                  int64                  `json:"age,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`                   // All unmatched properties
+}
+
+type marshalNoTypeWithExample NoTypeWithExample
+
+// UnmarshalJSON decodes JSON.
+func (i *NoTypeWithExample) UnmarshalJSON(data []byte) error {
+	ii := marshalNoTypeWithExample(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"firstName",
+			"lastName",
+			"age",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = NoTypeWithExample(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i NoTypeWithExample) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalNoTypeWithExample(i), i.AdditionalProperties)
+}
+
+// Address structure is generated from "#/definitions/address".
+type Address struct {
+	Stripped             string                 `json:"addressStripped,omitempty"`
+	Address1             string                 `json:"address1,omitempty"`
+	Address2             string                 `json:"address2,omitempty"`
+	City                 string                 `json:"city,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`                         // All unmatched properties
+}
+
+type marshalAddress Address
+
+// UnmarshalJSON decodes JSON.
+func (i *Address) UnmarshalJSON(data []byte) error {
+	ii := marshalAddress(*i)
+
+	err := unionMap{
+		mustUnmarshal: []interface{}{&ii},
+		ignoreKeys: []string{
+			"addressStripped",
+			"address1",
+			"address2",
+			"city",
+		},
+		additionalProperties: &ii.AdditionalProperties,
+		jsonData: data,
+	}.unmarshal()
+	if err != nil {
+		return err
+	}
+	*i = Address(ii)
+	return err
+}
+
+// MarshalJSON encodes JSON.
+func (i Address) MarshalJSON() ([]byte, error) {
+	return marshalUnion(marshalAddress(i), i.AdditionalProperties)
 }
 
 // Table structure is generated from "#/definitions/table".

--- a/tests/resources/go/asyncapi2/entities.go
+++ b/tests/resources/go/asyncapi2/entities.go
@@ -1004,14 +1004,14 @@ func (i MessageTrait) MarshalJSON() ([]byte, error) {
 // MessageTraitHeaders structure is generated from "#/definitions/messageTrait->headers".
 type MessageTraitHeaders struct {
 	Reference *Reference             `json:"-"`
-	OneOf1    map[string]interface{} `json:"-"`
+	Schema    map[string]interface{} `json:"-"`
 }
 
 type marshalMessageTraitHeaders MessageTraitHeaders
 
 // UnmarshalJSON decodes JSON.
 func (i *MessageTraitHeaders) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Reference, &i.OneOf1}
+	mayUnmarshal := []interface{}{&i.Reference, &i.Schema}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -1020,7 +1020,7 @@ func (i *MessageTraitHeaders) UnmarshalJSON(data []byte) error {
 		i.Reference = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.OneOf1 = nil
+		i.Schema = nil
 	}
 
 	return err
@@ -1028,7 +1028,7 @@ func (i *MessageTraitHeaders) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i MessageTraitHeaders) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalMessageTraitHeaders(i), i.Reference, i.OneOf1)
+	return marshalUnion(marshalMessageTraitHeaders(i), i.Reference, i.Schema)
 }
 
 // MessageTraitCorrelationID structure is generated from "#/definitions/messageTrait->correlationId".

--- a/tests/resources/go/draft7/entities.go
+++ b/tests/resources/go/draft7/entities.go
@@ -31,7 +31,6 @@ type CoreSchemaMetaSchema struct {
 	MaxLength            *int64                                      `json:"maxLength,omitempty"`
 	MinLength            int64                                       `json:"minLength,omitempty"`
 	Pattern              *string                                     `json:"pattern,omitempty"`
-	ExtraProperties      map[string]interface{}                      `json:"-"`                              // All unmatched properties
 	AdditionalItems      *Schema                                     `json:"additionalItems,omitempty"`      // Core schema meta-schema
 	Items                *Items                                      `json:"items,omitempty"`
 	MaxItems             *int64                                      `json:"maxItems,omitempty"`
@@ -60,6 +59,7 @@ type CoreSchemaMetaSchema struct {
 	AnyOf                []Schema                                    `json:"anyOf,omitempty"`
 	OneOf                []Schema                                    `json:"oneOf,omitempty"`
 	Not                  *Schema                                     `json:"not,omitempty"`                  // Core schema meta-schema
+	ExtraProperties      map[string]interface{}                      `json:"-"`                              // All unmatched properties
 }
 
 type marshalCoreSchemaMetaSchema CoreSchemaMetaSchema
@@ -166,15 +166,15 @@ func (i Schema) MarshalJSON() ([]byte, error) {
 
 // Items structure is generated from "#[object]->items".
 type Items struct {
-	Schema              *Schema  `json:"-"`
-	SliceOfSchemaValues []Schema `json:"-"`
+	Schema      *Schema  `json:"-"`
+	SchemaArray []Schema `json:"-"`
 }
 
 type marshalItems Items
 
 // UnmarshalJSON decodes JSON.
 func (i *Items) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Schema, &i.SliceOfSchemaValues}
+	mayUnmarshal := []interface{}{&i.Schema, &i.SchemaArray}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -183,7 +183,7 @@ func (i *Items) UnmarshalJSON(data []byte) error {
 		i.Schema = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.SliceOfSchemaValues = nil
+		i.SchemaArray = nil
 	}
 
 	return err
@@ -191,20 +191,20 @@ func (i *Items) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Items) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalItems(i), i.Schema, i.SliceOfSchemaValues)
+	return marshalUnion(marshalItems(i), i.Schema, i.SchemaArray)
 }
 
 // DependenciesAdditionalProperties structure is generated from "#[object]->dependencies->additionalProperties".
 type DependenciesAdditionalProperties struct {
-	Schema              *Schema  `json:"-"`
-	SliceOfStringValues []string `json:"-"`
+	Schema      *Schema  `json:"-"`
+	StringArray []string `json:"-"`
 }
 
 type marshalDependenciesAdditionalProperties DependenciesAdditionalProperties
 
 // UnmarshalJSON decodes JSON.
 func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
-	mayUnmarshal := []interface{}{&i.Schema, &i.SliceOfStringValues}
+	mayUnmarshal := []interface{}{&i.Schema, &i.StringArray}
 	err := unionMap{
 		mayUnmarshal: mayUnmarshal,
 		jsonData: data,
@@ -213,7 +213,7 @@ func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
 		i.Schema = nil
 	}
 	if mayUnmarshal[1] == nil {
-		i.SliceOfStringValues = nil
+		i.StringArray = nil
 	}
 
 	return err
@@ -221,7 +221,7 @@ func (i *DependenciesAdditionalProperties) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i DependenciesAdditionalProperties) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalDependenciesAdditionalProperties(i), i.Schema, i.SliceOfStringValues)
+	return marshalUnion(marshalDependenciesAdditionalProperties(i), i.Schema, i.StringArray)
 }
 
 // Type structure is generated from "#[object]->type".

--- a/tests/resources/go/openapi3/entities.go
+++ b/tests/resources/go/openapi3/entities.go
@@ -375,22 +375,22 @@ func (i PathItem) MarshalJSON() ([]byte, error) {
 
 // Parameter structure is generated from "#/definitions/Parameter".
 type Parameter struct {
-	Name                   string                                           `json:"name,omitempty"`
-	In                     string                                           `json:"in,omitempty"`
-	Description            string                                           `json:"description,omitempty"`
-	Required               bool                                             `json:"required,omitempty"`
-	Deprecated             bool                                             `json:"deprecated,omitempty"`
-	AllowEmptyValue        bool                                             `json:"allowEmptyValue,omitempty"`
-	Style                  string                                           `json:"style,omitempty"`
-	Explode                bool                                             `json:"explode,omitempty"`
-	AllowReserved          bool                                             `json:"allowReserved,omitempty"`
-	Schema                 *ParameterSchema                                 `json:"schema,omitempty"`
-	Content                map[string]MediaType                             `json:"content,omitempty"`
-	Example                interface{}                                      `json:"example,omitempty"`
-	Examples               map[string]ParameterExamplesAdditionalProperties `json:"examples,omitempty"`
-	SchemaXORContentOneOf1 *SchemaXORContentOneOf1                          `json:"-"`
-	Location               *ParameterLocation                               `json:"-"`
-	MapOfAnything          map[string]interface{}                           `json:"-"`                         // Key must match pattern: ^x-
+	Name             string                                           `json:"name,omitempty"`
+	In               string                                           `json:"in,omitempty"`
+	Description      string                                           `json:"description,omitempty"`
+	Required         bool                                             `json:"required,omitempty"`
+	Deprecated       bool                                             `json:"deprecated,omitempty"`
+	AllowEmptyValue  bool                                             `json:"allowEmptyValue,omitempty"`
+	Style            string                                           `json:"style,omitempty"`
+	Explode          bool                                             `json:"explode,omitempty"`
+	AllowReserved    bool                                             `json:"allowReserved,omitempty"`
+	Schema           *ParameterSchema                                 `json:"schema,omitempty"`
+	Content          map[string]MediaType                             `json:"content,omitempty"`
+	Example          interface{}                                      `json:"example,omitempty"`
+	Examples         map[string]ParameterExamplesAdditionalProperties `json:"examples,omitempty"`
+	SchemaXORContent *SchemaXORContentOneOf1                          `json:"-"`
+	Location         *ParameterLocation                               `json:"-"`
+	MapOfAnything    map[string]interface{}                           `json:"-"`                         // Key must match pattern: ^x-
 }
 
 type marshalParameter Parameter
@@ -400,7 +400,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 	ii := marshalParameter(*i)
 
 	err := unionMap{
-		mustUnmarshal: []interface{}{&ii, &ii.SchemaXORContentOneOf1, &ii.Location},
+		mustUnmarshal: []interface{}{&ii, &ii.SchemaXORContent, &ii.Location},
 		ignoreKeys: []string{
 			"name",
 			"in",
@@ -430,7 +430,7 @@ func (i *Parameter) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON encodes JSON.
 func (i Parameter) MarshalJSON() ([]byte, error) {
-	return marshalUnion(marshalParameter(i), i.MapOfAnything, i.SchemaXORContentOneOf1, i.Location)
+	return marshalUnion(marshalParameter(i), i.MapOfAnything, i.SchemaXORContent, i.Location)
 }
 
 // Schema structure is generated from "#/definitions/Schema".

--- a/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
+++ b/tests/src/PHPUnit/JsonSchema/AdvancedTest.php
@@ -20,6 +20,8 @@ class AdvancedTest extends \PHPUnit_Framework_TestCase
         $builder = new GoBuilder();
         $builder->options->hideConstProperties = true;
         $builder->options->trimParentFromPropertyNames = true;
+        $builder->options->inheritSchemaFromExamples = true;
+
         $builder->structCreatedHook = new StructHookCallback(function (StructDef $structDef, $path, $schema) use ($builder) {
             if ('#' === $path) {
                 $structDef->setName('Properties');


### PR DESCRIPTION
…re missing.

Fix invalid property name when stripping parent prefix.
Inherit names for logical branches from reference names where available.